### PR TITLE
Update developer instructions to use docker to build the binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /swarm
+dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
-FROM golang:1.5
+FROM    debian:jessie
 
-COPY . /go/src/github.com/docker/swarm
-WORKDIR /go/src/github.com/docker/swarm
+RUN     apt-get update && \
+        apt-get install -y --no-install-recommends ca-certificates
 
-ENV GOPATH /go/src/github.com/docker/swarm/Godeps/_workspace:$GOPATH
-RUN CGO_ENABLED=0 go install -v -a -tags netgo -installsuffix netgo -ldflags "-w -X github.com/docker/swarm/version.GITCOMMIT `git rev-parse --short HEAD`"
+COPY    dist/bin/swarm /swarm
+ENV     SWARM_HOST :2375
+EXPOSE  2375
+VOLUME  /.swarm
 
-ENV SWARM_HOST :2375
-EXPOSE 2375
-
-VOLUME $HOME/.swarm
-
-ENTRYPOINT ["swarm"]
+ENTRYPOINT ["/swarm"]
 CMD ["--help"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,9 @@
+
+FROM    golang:1.5
+RUN     mkdir -p /tmp/godep && \
+        GOPATH=/tmp/godep go get github.com/tools/godep && \
+        mv /tmp/godep/bin/godep /usr/local/bin/godep && \
+        rm -rf /tmp/godep
+
+WORKDIR /go/src/github.com/docker/swarm
+CMD     ["godep", "go", "install", "."]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -6,4 +6,10 @@ RUN     mkdir -p /tmp/godep && \
         rm -rf /tmp/godep
 
 WORKDIR /go/src/github.com/docker/swarm
-CMD     ["godep", "go", "install", "."]
+
+ENV     CGO_ENABLED=0
+
+CMD     godep go install -v -a \
+            -tags netgo \
+            -installsuffix netgo \
+            -ldflags "-w -X github.com/docker/swarm/version.GITCOMMIT=$VERSION"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: build binary shell build_image
+
+
+BUILD_ID ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+DOCKER_IMAGE := swarm-dev:$(BUILD_ID)
+
+VOLUMES := \
+	-v $(CURDIR):/go/src/github.com/docker/swarm \
+	-v $(CURDIR)/dist/bin:/go/bin \
+	-v $(CURDIR)/dist/pkg:/go/pkg
+
+all: binary
+
+build:
+	docker build -t $(DOCKER_IMAGE) -f Dockerfile.build .
+
+dist:
+	mkdir dist/
+
+binary: dist build
+	docker run --rm $(VOLUMES) $(DOCKER_IMAGE)
+
+shell: dist build
+	docker run --rm -ti $(VOLUMES) $(DOCKER_IMAGE) bash

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build binary shell build_image
 
 
-BUILD_ID ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+BUILD_ID ?= $(shell git rev-parse --short HEAD 2>/dev/null)
 DOCKER_IMAGE := swarm-dev:$(BUILD_ID)
 
 VOLUMES := \
@@ -18,7 +18,10 @@ dist:
 	mkdir dist/
 
 binary: dist build
-	docker run --rm $(VOLUMES) $(DOCKER_IMAGE)
+	docker run --rm -e VERSION=$(BUILD_ID) $(VOLUMES) $(DOCKER_IMAGE)
 
 shell: dist build
 	docker run --rm -ti $(VOLUMES) $(DOCKER_IMAGE) bash
+
+build_image: binary
+	docker build -t swarm:$(BUILD_ID) .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build binary shell build_image
+.PHONY: build binary shell build-image test-unit test-integration test-regression
 
 
 BUILD_ID ?= $(shell git rev-parse --short HEAD 2>/dev/null)
@@ -23,5 +23,14 @@ binary: dist build
 shell: dist build
 	docker run --rm -ti $(VOLUMES) $(DOCKER_IMAGE) bash
 
-build_image: binary
+build-image: binary
 	docker build -t swarm:$(BUILD_ID) .
+
+test-unit: build
+	docker run --rm -ti $(VOLUMES) $(DOCKER_IMAGE) godep go test -v ./...
+
+test-integration:
+	test/integration/run.sh
+
+test-regression:
+	./test/regression/run.sh

--- a/README.md
+++ b/README.md
@@ -32,9 +32,20 @@ documentation on [docs.docker.com](http://docs.docker.com/swarm/).
 Developers should always download and install from source rather than
 using the Docker image.
 
-### Prerequisites
+### Developing with Docker
 
-1. Beginning with Swarm 0.4 golang 1.4.x or later is required for building Swarm. 
+Install [Docker](http://docs.docker.com/installation/)
+
+```bash
+$ git clone git@github.com:docker/swarm && cd swarm
+$ make binary
+```
+
+### Developing on the host
+
+#### Prerequisites
+
+1. Beginning with Swarm 0.4 golang 1.4.x or later is required for building Swarm.
 Refer to the [Go installation page](https://golang.org/doc/install#install)
 to download and install the golang 1.4.x or later package.
 > **Note**: On Ubuntu 14.04, the `apt-get` repositories install golang 1.2.1 version by
@@ -45,11 +56,11 @@ to download and install the golang 1.4.x or later package.
 
 3. Install [godep](https://github.com/tools/godep).
 
-### Clone and build Swarm
+#### Clone and build Swarm
 
 > **Note** `GOPATH` should be set when install godep in above step.
 
-Install the `swarm` binary in the `$GOPATH/bin` directory. An easy way to do this 
+Install the `swarm` binary in the `$GOPATH/bin` directory. An easy way to do this
 is using the `go get` command.
 
 ```bash


### PR DESCRIPTION
This change splits the `Dockerfile` into a `Dockerfile.build` that is used to build or develop (so no operations need to be done on the host, and a runtime `Dockerfile` for running the binary.  The runtime `Dockerfile` is pretty similar to https://github.com/docker/swarm-library-image/blob/master/Dockerfile but without the certs (so I guess it's really only for development).

I realize this is a rather intrusive change, feedback appreciated. 

I tried to use the `Makefile` conventions from the docker engine repo.
