### PR TITLE
ACLs in Swarm see #1199 (ReOpen for #1365)

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -350,6 +350,10 @@
 		{
 			"ImportPath": "golang.org/x/sys/unix",
 			"Rev": "833a04a10549a95dc34458c195cbad61bbb6cb4d"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/pkg/authorization",
+			"Rev": "78076d5cf9413476a8d4e27822b96fef7a55e055"
 		}
 	]
 }

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/authorization/api.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/authorization/api.go
@@ -1,0 +1,54 @@
+package authorization
+
+const (
+	// AuthZApiRequest is the url for daemon request authorization
+	AuthZApiRequest = "AuthZPlugin.AuthZReq"
+
+	// AuthZApiResponse is the url for daemon response authorization
+	AuthZApiResponse = "AuthZPlugin.AuthZRes"
+
+	// AuthZApiImplements is the name of the interface all AuthZ plugins implement
+	AuthZApiImplements = "authz"
+)
+
+// Request holds data required for authZ plugins
+type Request struct {
+	// User holds the user extracted by AuthN mechanism
+	User string `json:"User,omitempty"`
+
+	// UserAuthNMethod holds the mechanism used to extract user details (e.g., krb)
+	UserAuthNMethod string `json:"UserAuthNMethod,omitempty"`
+
+	// RequestMethod holds the HTTP method (GET/POST/PUT)
+	RequestMethod string `json:"RequestMethod,omitempty"`
+
+	// RequestUri holds the full HTTP uri (e.g., /v1.21/version)
+	RequestURI string `json:"RequestUri,omitempty"`
+
+	// RequestBody stores the raw request body sent to the docker daemon
+	RequestBody []byte `json:"RequestBody,omitempty"`
+
+	// RequestHeaders stores the raw request headers sent to the docker daemon
+	RequestHeaders map[string]string `json:"RequestHeaders,omitempty"`
+
+	// ResponseStatusCode stores the status code returned from docker daemon
+	ResponseStatusCode int `json:"ResponseStatusCode,omitempty"`
+
+	// ResponseBody stores the raw response body sent from docker daemon
+	ResponseBody []byte `json:"ResponseBody,omitempty"`
+
+	// ResponseHeaders stores the response headers sent to the docker daemon
+	ResponseHeaders map[string]string `json:"ResponseHeaders,omitempty"`
+}
+
+// Response represents authZ plugin response
+type Response struct {
+	// Allow indicating whether the user is allowed or not
+	Allow bool `json:"Allow"`
+
+	// Msg stores the authorization message
+	Msg string `json:"Msg,omitempty"`
+
+	// Err stores a message in case there's an error
+	Err string `json:"Err,omitempty"`
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/authorization/authz.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/authorization/authz.go
@@ -1,0 +1,165 @@
+package authorization
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/ioutils"
+)
+
+const maxBodySize = 1048576 // 1MB
+
+// NewCtx creates new authZ context, it is used to store authorization information related to a specific docker
+// REST http session
+// A context provides two method:
+// Authenticate Request:
+// Call authZ plugins with current REST request and AuthN response
+// Request contains full HTTP packet sent to the docker daemon
+// https://docs.docker.com/reference/api/docker_remote_api/
+//
+// Authenticate Response:
+// Call authZ plugins with full info about current REST request, REST response and AuthN response
+// The response from this method may contains content that overrides the daemon response
+// This allows authZ plugins to filter privileged content
+//
+// If multiple authZ plugins are specified, the block/allow decision is based on ANDing all plugin results
+// For response manipulation, the response from each plugin is piped between plugins. Plugin execution order
+// is determined according to daemon parameters
+func NewCtx(authZPlugins []Plugin, user, userAuthNMethod, requestMethod, requestURI string) *Ctx {
+	return &Ctx{
+		plugins:         authZPlugins,
+		user:            user,
+		userAuthNMethod: userAuthNMethod,
+		requestMethod:   requestMethod,
+		requestURI:      requestURI,
+	}
+}
+
+// Ctx stores a a single request-response interaction context
+type Ctx struct {
+	user            string
+	userAuthNMethod string
+	requestMethod   string
+	requestURI      string
+	plugins         []Plugin
+	// authReq stores the cached request object for the current transaction
+	authReq *Request
+}
+
+// AuthZRequest authorized the request to the docker daemon using authZ plugins
+func (ctx *Ctx) AuthZRequest(w http.ResponseWriter, r *http.Request) error {
+	var body []byte
+	if sendBody(ctx.requestURI, r.Header) && r.ContentLength > 0 && r.ContentLength < maxBodySize {
+		var err error
+		body, r.Body, err = drainBody(r.Body)
+		if err != nil {
+			return err
+		}
+	}
+
+	var h bytes.Buffer
+	if err := r.Header.Write(&h); err != nil {
+		return err
+	}
+
+	ctx.authReq = &Request{
+		User:            ctx.user,
+		UserAuthNMethod: ctx.userAuthNMethod,
+		RequestMethod:   ctx.requestMethod,
+		RequestURI:      ctx.requestURI,
+		RequestBody:     body,
+		RequestHeaders:  headers(r.Header),
+	}
+
+	for _, plugin := range ctx.plugins {
+		logrus.Debugf("AuthZ request using plugin %s", plugin.Name())
+
+		authRes, err := plugin.AuthZRequest(ctx.authReq)
+		if err != nil {
+			return fmt.Errorf("plugin %s failed with error: %s", plugin.Name(), err)
+		}
+
+		if !authRes.Allow {
+			return fmt.Errorf("authorization denied by plugin %s: %s", plugin.Name(), authRes.Msg)
+		}
+	}
+
+	return nil
+}
+
+// AuthZResponse authorized and manipulates the response from docker daemon using authZ plugins
+func (ctx *Ctx) AuthZResponse(rm ResponseModifier, r *http.Request) error {
+	ctx.authReq.ResponseStatusCode = rm.StatusCode()
+	ctx.authReq.ResponseHeaders = headers(rm.Header())
+
+	if sendBody(ctx.requestURI, rm.Header()) {
+		ctx.authReq.ResponseBody = rm.RawBody()
+	}
+
+	for _, plugin := range ctx.plugins {
+		logrus.Debugf("AuthZ response using plugin %s", plugin.Name())
+
+		authRes, err := plugin.AuthZResponse(ctx.authReq)
+		if err != nil {
+			return fmt.Errorf("plugin %s failed with error: %s", plugin.Name(), err)
+		}
+
+		if !authRes.Allow {
+			return fmt.Errorf("authorization denied by plugin %s: %s", plugin.Name(), authRes.Msg)
+		}
+	}
+
+	rm.FlushAll()
+
+	return nil
+}
+
+// drainBody dump the body (if it's length is less than 1MB) without modifying the request state
+func drainBody(body io.ReadCloser) ([]byte, io.ReadCloser, error) {
+	bufReader := bufio.NewReaderSize(body, maxBodySize)
+	newBody := ioutils.NewReadCloserWrapper(bufReader, func() error { return body.Close() })
+
+	data, err := bufReader.Peek(maxBodySize)
+	// Body size exceeds max body size
+	if err == nil {
+		logrus.Warnf("Request body is larger than: '%d' skipping body", maxBodySize)
+		return nil, newBody, nil
+	}
+	// Body size is less than maximum size
+	if err == io.EOF {
+		return data, newBody, nil
+	}
+	// Unknown error
+	return nil, newBody, err
+}
+
+// sendBody returns true when request/response body should be sent to AuthZPlugin
+func sendBody(url string, header http.Header) bool {
+	// Skip body for auth endpoint
+	if strings.HasSuffix(url, "/auth") {
+		return false
+	}
+
+	// body is sent only for text or json messages
+	return header.Get("Content-Type") == "application/json"
+}
+
+// headers returns flatten version of the http headers excluding authorization
+func headers(header http.Header) map[string]string {
+	v := make(map[string]string, 0)
+	for k, values := range header {
+		// Skip authorization headers
+		if strings.EqualFold(k, "Authorization") || strings.EqualFold(k, "X-Registry-Config") || strings.EqualFold(k, "X-Registry-Auth") {
+			continue
+		}
+		for _, val := range values {
+			v[k] = val
+		}
+	}
+	return v
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/authorization/plugin.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/authorization/plugin.go
@@ -1,0 +1,83 @@
+package authorization
+
+import "github.com/docker/docker/pkg/plugins"
+
+// Plugin allows third party plugins to authorize requests and responses
+// in the context of docker API
+type Plugin interface {
+	// Name returns the registered plugin name
+	Name() string
+
+	// AuthZRequest authorize the request from the client to the daemon
+	AuthZRequest(*Request) (*Response, error)
+
+	// AuthZResponse authorize the response from the daemon to the client
+	AuthZResponse(*Request) (*Response, error)
+}
+
+// NewPlugins constructs and initialize the authorization plugins based on plugin names
+func NewPlugins(names []string) []Plugin {
+	plugins := []Plugin{}
+	pluginsMap := make(map[string]struct{})
+	for _, name := range names {
+		if _, ok := pluginsMap[name]; ok {
+			continue
+		}
+		pluginsMap[name] = struct{}{}
+		plugins = append(plugins, newAuthorizationPlugin(name))
+	}
+	return plugins
+}
+
+// authorizationPlugin is an internal adapter to docker plugin system
+type authorizationPlugin struct {
+	plugin *plugins.Plugin
+	name   string
+}
+
+func newAuthorizationPlugin(name string) Plugin {
+	return &authorizationPlugin{name: name}
+}
+
+func (a *authorizationPlugin) Name() string {
+	return a.name
+}
+
+func (a *authorizationPlugin) AuthZRequest(authReq *Request) (*Response, error) {
+	if err := a.initPlugin(); err != nil {
+		return nil, err
+	}
+
+	authRes := &Response{}
+	if err := a.plugin.Client.Call(AuthZApiRequest, authReq, authRes); err != nil {
+		return nil, err
+	}
+
+	return authRes, nil
+}
+
+func (a *authorizationPlugin) AuthZResponse(authReq *Request) (*Response, error) {
+	if err := a.initPlugin(); err != nil {
+		return nil, err
+	}
+
+	authRes := &Response{}
+	if err := a.plugin.Client.Call(AuthZApiResponse, authReq, authRes); err != nil {
+		return nil, err
+	}
+
+	return authRes, nil
+}
+
+// initPlugin initialize the authorization plugin if needed
+func (a *authorizationPlugin) initPlugin() error {
+	// Lazy loading of plugins
+	if a.plugin == nil {
+		var err error
+		a.plugin, err = plugins.Get(a.name, AuthZApiImplements)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/authorization/response.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/authorization/response.go
@@ -1,0 +1,203 @@
+package authorization
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/Sirupsen/logrus"
+	"net"
+	"net/http"
+)
+
+// ResponseModifier allows authorization plugins to read and modify the content of the http.response
+type ResponseModifier interface {
+	http.ResponseWriter
+	http.Flusher
+	http.CloseNotifier
+
+	// RawBody returns the current http content
+	RawBody() []byte
+
+	// RawHeaders returns the current content of the http headers
+	RawHeaders() ([]byte, error)
+
+	// StatusCode returns the current status code
+	StatusCode() int
+
+	// OverrideBody replace the body of the HTTP reply
+	OverrideBody(b []byte)
+
+	// OverrideHeader replace the headers of the HTTP reply
+	OverrideHeader(b []byte) error
+
+	// OverrideStatusCode replaces the status code of the HTTP reply
+	OverrideStatusCode(statusCode int)
+
+	// Flush flushes all data to the HTTP response
+	FlushAll() error
+
+	// Hijacked indicates the response has been hijacked by the Docker daemon
+	Hijacked() bool
+}
+
+// NewResponseModifier creates a wrapper to an http.ResponseWriter to allow inspecting and modifying the content
+func NewResponseModifier(rw http.ResponseWriter) ResponseModifier {
+	return &responseModifier{rw: rw, header: make(http.Header)}
+}
+
+// responseModifier is used as an adapter to http.ResponseWriter in order to manipulate and explore
+// the http request/response from docker daemon
+type responseModifier struct {
+	// The original response writer
+	rw http.ResponseWriter
+
+	r *http.Request
+
+	status int
+	// body holds the response body
+	body []byte
+	// header holds the response header
+	header http.Header
+	// statusCode holds the response status code
+	statusCode int
+	// hijacked indicates the request has been hijacked
+	hijacked bool
+}
+
+func (rm *responseModifier) Hijacked() bool {
+	return rm.hijacked
+}
+
+// WriterHeader stores the http status code
+func (rm *responseModifier) WriteHeader(s int) {
+
+	// Use original request if hijacked
+	if rm.hijacked {
+		rm.rw.WriteHeader(s)
+		return
+	}
+
+	rm.statusCode = s
+}
+
+// Header returns the internal http header
+func (rm *responseModifier) Header() http.Header {
+
+	// Use original header if hijacked
+	if rm.hijacked {
+		return rm.rw.Header()
+	}
+
+	return rm.header
+}
+
+// Header returns the internal http header
+func (rm *responseModifier) StatusCode() int {
+	return rm.statusCode
+}
+
+// Override replace the body of the HTTP reply
+func (rm *responseModifier) OverrideBody(b []byte) {
+	rm.body = b
+}
+
+func (rm *responseModifier) OverrideStatusCode(statusCode int) {
+	rm.statusCode = statusCode
+}
+
+// Override replace the headers of the HTTP reply
+func (rm *responseModifier) OverrideHeader(b []byte) error {
+	header := http.Header{}
+	if err := json.Unmarshal(b, &header); err != nil {
+		return err
+	}
+	rm.header = header
+	return nil
+}
+
+// Write stores the byte array inside content
+func (rm *responseModifier) Write(b []byte) (int, error) {
+
+	if rm.hijacked {
+		return rm.rw.Write(b)
+	}
+
+	rm.body = append(rm.body, b...)
+	return len(b), nil
+}
+
+// Body returns the response body
+func (rm *responseModifier) RawBody() []byte {
+	return rm.body
+}
+
+func (rm *responseModifier) RawHeaders() ([]byte, error) {
+	var b bytes.Buffer
+	if err := rm.header.Write(&b); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+// Hijack returns the internal connection of the wrapped http.ResponseWriter
+func (rm *responseModifier) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+
+	rm.hijacked = true
+	rm.FlushAll()
+
+	hijacker, ok := rm.rw.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("Internal response writer doesn't support the Hijacker interface")
+	}
+	return hijacker.Hijack()
+}
+
+// CloseNotify uses the internal close notify API of the wrapped http.ResponseWriter
+func (rm *responseModifier) CloseNotify() <-chan bool {
+	closeNotifier, ok := rm.rw.(http.CloseNotifier)
+	if !ok {
+		logrus.Errorf("Internal response writer doesn't support the CloseNotifier interface")
+		return nil
+	}
+	return closeNotifier.CloseNotify()
+}
+
+// Flush uses the internal flush API of the wrapped http.ResponseWriter
+func (rm *responseModifier) Flush() {
+	flusher, ok := rm.rw.(http.Flusher)
+	if !ok {
+		logrus.Errorf("Internal response writer doesn't support the Flusher interface")
+		return
+	}
+
+	rm.FlushAll()
+	flusher.Flush()
+}
+
+// FlushAll flushes all data to the HTTP response
+func (rm *responseModifier) FlushAll() error {
+	// Copy the status code
+	if rm.statusCode > 0 {
+		rm.rw.WriteHeader(rm.statusCode)
+	}
+
+	// Copy the header
+	for k, vv := range rm.header {
+		for _, v := range vv {
+			rm.rw.Header().Add(k, v)
+		}
+	}
+
+	var err error
+	if len(rm.body) > 0 {
+		// Write body
+		_, err = rm.rw.Write(rm.body)
+	}
+
+	// Clean previous data
+	rm.body = nil
+	rm.statusCode = 0
+	rm.header = http.Header{}
+	return err
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/client.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/client.go
@@ -1,0 +1,186 @@
+package plugins
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/plugins/transport"
+	"github.com/docker/go-connections/sockets"
+	"github.com/docker/go-connections/tlsconfig"
+)
+
+const (
+	defaultTimeOut = 30
+)
+
+// NewClient creates a new plugin client (http).
+func NewClient(addr string, tlsConfig tlsconfig.Options) (*Client, error) {
+	tr := &http.Transport{}
+
+	c, err := tlsconfig.Client(tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+	tr.TLSClientConfig = c
+
+	u, err := url.Parse(addr)
+	if err != nil {
+		return nil, err
+	}
+	socket := u.Host
+	if socket == "" {
+		// valid local socket addresses have the host empty.
+		socket = u.Path
+	}
+	if err := sockets.ConfigureTransport(tr, u.Scheme, socket); err != nil {
+		return nil, err
+	}
+	scheme := httpScheme(u)
+
+	clientTransport := transport.NewHTTPTransport(tr, scheme, socket)
+	return NewClientWithTransport(clientTransport), nil
+}
+
+// NewClientWithTransport creates a new plugin client with a given transport.
+func NewClientWithTransport(tr transport.Transport) *Client {
+	return &Client{
+		http: &http.Client{
+			Transport: tr,
+		},
+		requestFactory: tr,
+	}
+}
+
+// Client represents a plugin client.
+type Client struct {
+	http           *http.Client // http client to use
+	requestFactory transport.RequestFactory
+}
+
+// Call calls the specified method with the specified arguments for the plugin.
+// It will retry for 30 seconds if a failure occurs when calling.
+func (c *Client) Call(serviceMethod string, args interface{}, ret interface{}) error {
+	var buf bytes.Buffer
+	if args != nil {
+		if err := json.NewEncoder(&buf).Encode(args); err != nil {
+			return err
+		}
+	}
+	body, err := c.callWithRetry(serviceMethod, &buf, true)
+	if err != nil {
+		return err
+	}
+	defer body.Close()
+	if ret != nil {
+		if err := json.NewDecoder(body).Decode(&ret); err != nil {
+			logrus.Errorf("%s: error reading plugin resp: %v", serviceMethod, err)
+			return err
+		}
+	}
+	return nil
+}
+
+// Stream calls the specified method with the specified arguments for the plugin and returns the response body
+func (c *Client) Stream(serviceMethod string, args interface{}) (io.ReadCloser, error) {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(args); err != nil {
+		return nil, err
+	}
+	return c.callWithRetry(serviceMethod, &buf, true)
+}
+
+// SendFile calls the specified method, and passes through the IO stream
+func (c *Client) SendFile(serviceMethod string, data io.Reader, ret interface{}) error {
+	body, err := c.callWithRetry(serviceMethod, data, true)
+	if err != nil {
+		return err
+	}
+	defer body.Close()
+	if err := json.NewDecoder(body).Decode(&ret); err != nil {
+		logrus.Errorf("%s: error reading plugin resp: %v", serviceMethod, err)
+		return err
+	}
+	return nil
+}
+
+func (c *Client) callWithRetry(serviceMethod string, data io.Reader, retry bool) (io.ReadCloser, error) {
+	req, err := c.requestFactory.NewRequest(serviceMethod, data)
+	if err != nil {
+		return nil, err
+	}
+
+	var retries int
+	start := time.Now()
+
+	for {
+		resp, err := c.http.Do(req)
+		if err != nil {
+			if !retry {
+				return nil, err
+			}
+
+			timeOff := backoff(retries)
+			if abort(start, timeOff) {
+				return nil, err
+			}
+			retries++
+			logrus.Warnf("Unable to connect to plugin: %s:%s, retrying in %v", req.URL.Host, req.URL.Path, timeOff)
+			time.Sleep(timeOff)
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			b, err := ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil {
+				return nil, &statusError{resp.StatusCode, serviceMethod, err.Error()}
+			}
+
+			// Plugins' Response(s) should have an Err field indicating what went
+			// wrong. Try to unmarshal into ResponseErr. Otherwise fallback to just
+			// return the string(body)
+			type responseErr struct {
+				Err string
+			}
+			remoteErr := responseErr{}
+			if err := json.Unmarshal(b, &remoteErr); err == nil {
+				if remoteErr.Err != "" {
+					return nil, &statusError{resp.StatusCode, serviceMethod, remoteErr.Err}
+				}
+			}
+			// old way...
+			return nil, &statusError{resp.StatusCode, serviceMethod, string(b)}
+		}
+		return resp.Body, nil
+	}
+}
+
+func backoff(retries int) time.Duration {
+	b, max := 1, defaultTimeOut
+	for b < max && retries > 0 {
+		b *= 2
+		retries--
+	}
+	if b > max {
+		b = max
+	}
+	return time.Duration(b) * time.Second
+}
+
+func abort(start time.Time, timeOff time.Duration) bool {
+	return timeOff+time.Since(start) >= time.Duration(defaultTimeOut)*time.Second
+}
+
+func httpScheme(u *url.URL) string {
+	scheme := u.Scheme
+	if scheme != "https" {
+		scheme = "http"
+	}
+	return scheme
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/discovery.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/discovery.go
@@ -1,0 +1,130 @@
+package plugins
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	// ErrNotFound plugin not found
+	ErrNotFound = errors.New("plugin not found")
+	socketsPath = "/run/docker/plugins"
+	specsPaths  = []string{"/etc/docker/plugins", "/usr/lib/docker/plugins"}
+)
+
+// localRegistry defines a registry that is local (using unix socket).
+type localRegistry struct{}
+
+func newLocalRegistry() localRegistry {
+	return localRegistry{}
+}
+
+// Scan scans all the plugin paths and returns all the names it found
+func Scan() ([]string, error) {
+	var names []string
+	if err := filepath.Walk(socketsPath, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		if fi.Mode()&os.ModeSocket != 0 {
+			name := strings.TrimSuffix(fi.Name(), filepath.Ext(fi.Name()))
+			names = append(names, name)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	for _, path := range specsPaths {
+		if err := filepath.Walk(path, func(p string, fi os.FileInfo, err error) error {
+			if err != nil || fi.IsDir() {
+				return nil
+			}
+			name := strings.TrimSuffix(fi.Name(), filepath.Ext(fi.Name()))
+			names = append(names, name)
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return names, nil
+}
+
+// Plugin returns the plugin registered with the given name (or returns an error).
+func (l *localRegistry) Plugin(name string) (*Plugin, error) {
+	socketpaths := pluginPaths(socketsPath, name, ".sock")
+
+	for _, p := range socketpaths {
+		if fi, err := os.Stat(p); err == nil && fi.Mode()&os.ModeSocket != 0 {
+			return newLocalPlugin(name, "unix://"+p), nil
+		}
+	}
+
+	var txtspecpaths []string
+	for _, p := range specsPaths {
+		txtspecpaths = append(txtspecpaths, pluginPaths(p, name, ".spec")...)
+		txtspecpaths = append(txtspecpaths, pluginPaths(p, name, ".json")...)
+	}
+
+	for _, p := range txtspecpaths {
+		if _, err := os.Stat(p); err == nil {
+			if strings.HasSuffix(p, ".json") {
+				return readPluginJSONInfo(name, p)
+			}
+			return readPluginInfo(name, p)
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func readPluginInfo(name, path string) (*Plugin, error) {
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	addr := strings.TrimSpace(string(content))
+
+	u, err := url.Parse(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(u.Scheme) == 0 {
+		return nil, fmt.Errorf("Unknown protocol")
+	}
+
+	return newLocalPlugin(name, addr), nil
+}
+
+func readPluginJSONInfo(name, path string) (*Plugin, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var p Plugin
+	if err := json.NewDecoder(f).Decode(&p); err != nil {
+		return nil, err
+	}
+	p.Name = name
+	if len(p.TLSConfig.CAFile) == 0 {
+		p.TLSConfig.InsecureSkipVerify = true
+	}
+
+	return &p, nil
+}
+
+func pluginPaths(base, name, ext string) []string {
+	return []string{
+		filepath.Join(base, name+ext),
+		filepath.Join(base, name, name+ext),
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/errors.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/errors.go
@@ -1,0 +1,33 @@
+package plugins
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type statusError struct {
+	status int
+	method string
+	err    string
+}
+
+// Error returns a formatted string for this error type
+func (e *statusError) Error() string {
+	return fmt.Sprintf("%s: %v", e.method, e.err)
+}
+
+// IsNotFound indicates if the passed in error is from an http.StatusNotFound from the plugin
+func IsNotFound(err error) bool {
+	return isStatusError(err, http.StatusNotFound)
+}
+
+func isStatusError(err error, status int) bool {
+	if err == nil {
+		return false
+	}
+	e, ok := err.(*statusError)
+	if !ok {
+		return false
+	}
+	return e.status == status
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/pluginrpc-gen/README.md
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/pluginrpc-gen/README.md
@@ -1,0 +1,68 @@
+Plugin RPC Generator
+====================
+
+Generates go code from a Go interface definition for proxying between the plugin
+API and the subsystem being extended.
+
+## Usage
+
+Given an interface definition:
+
+```go
+type volumeDriver interface {
+	Create(name string, opts opts) (err error)
+	Remove(name string) (err error)
+	Path(name string) (mountpoint string, err error)
+	Mount(name string) (mountpoint string, err error)
+	Unmount(name string) (err error)
+}
+```
+
+**Note**: All function options and return values must be named in the definition.
+
+Run the generator:
+
+```bash
+$ pluginrpc-gen --type volumeDriver --name VolumeDriver -i volumes/drivers/extpoint.go -o volumes/drivers/proxy.go
+```
+
+Where:
+- `--type` is the name of the interface to use
+- `--name` is the subsystem that the plugin "Implements"
+- `-i` is the input file containing the interface definition
+- `-o` is the output file where the the generated code should go
+
+**Note**: The generated code will use the same package name as the one defined in the input file
+
+Optionally, you can skip functions on the interface that should not be
+implemented in the generated proxy code by passing in the function name to `--skip`.
+This flag can be specified multiple times.
+
+You can also add build tags that should be prepended to the generated code by
+supplying `--tag`. This flag can be specified multiple times.
+
+## Known issues
+
+The parser can currently only handle types which are not specifically a map or
+a slice.  
+You can, however, create a type that uses a map or a slice internally, for instance:
+
+```go
+type opts map[string]string
+```
+
+This `opts` type will work, whreas using a `map[string]string` directly will not.
+
+## go-generate
+
+You can also use this with go-generate, which is pretty awesome.  
+To do so, place the code at the top of the file which contains the interface
+definition (i.e., the input file):
+
+```go
+//go:generate pluginrpc-gen -i $GOFILE -o proxy.go -type volumeDriver -name VolumeDriver
+```
+
+Then cd to the package dir and run `go generate`
+
+**Note**: the `pluginrpc-gen` binary must be within your `$PATH`

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/pluginrpc-gen/fixtures/foo.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/pluginrpc-gen/fixtures/foo.go
@@ -1,0 +1,41 @@
+package foo
+
+type wobble struct {
+	Some      string
+	Val       string
+	Inception *wobble
+}
+
+// Fooer is an empty interface used for tests.
+type Fooer interface{}
+
+// Fooer2 is an interface used for tests.
+type Fooer2 interface {
+	Foo()
+}
+
+// Fooer3 is an interface used for tests.
+type Fooer3 interface {
+	Foo()
+	Bar(a string)
+	Baz(a string) (err error)
+	Qux(a, b string) (val string, err error)
+	Wobble() (w *wobble)
+	Wiggle() (w wobble)
+}
+
+// Fooer4 is an interface used for tests.
+type Fooer4 interface {
+	Foo() error
+}
+
+// Bar is an interface used for tests.
+type Bar interface {
+	Boo(a string, b string) (s string, err error)
+}
+
+// Fooer5 is an interface used for tests.
+type Fooer5 interface {
+	Foo()
+	Bar
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/pluginrpc-gen/main.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/pluginrpc-gen/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"go/format"
+	"io/ioutil"
+	"os"
+	"unicode"
+	"unicode/utf8"
+)
+
+type stringSet struct {
+	values map[string]struct{}
+}
+
+func (s stringSet) String() string {
+	return ""
+}
+
+func (s stringSet) Set(value string) error {
+	s.values[value] = struct{}{}
+	return nil
+}
+func (s stringSet) GetValues() map[string]struct{} {
+	return s.values
+}
+
+var (
+	typeName   = flag.String("type", "", "interface type to generate plugin rpc proxy for")
+	rpcName    = flag.String("name", *typeName, "RPC name, set if different from type")
+	inputFile  = flag.String("i", "", "input file path")
+	outputFile = flag.String("o", *inputFile+"_proxy.go", "output file path")
+
+	skipFuncs   map[string]struct{}
+	flSkipFuncs = stringSet{make(map[string]struct{})}
+
+	flBuildTags = stringSet{make(map[string]struct{})}
+)
+
+func errorOut(msg string, err error) {
+	if err == nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "%s: %v\n", msg, err)
+	os.Exit(1)
+}
+
+func checkFlags() error {
+	if *outputFile == "" {
+		return fmt.Errorf("missing required flag `-o`")
+	}
+	if *inputFile == "" {
+		return fmt.Errorf("missing required flag `-i`")
+	}
+	return nil
+}
+
+func main() {
+	flag.Var(flSkipFuncs, "skip", "skip parsing for function")
+	flag.Var(flBuildTags, "tag", "build tags to add to generated files")
+	flag.Parse()
+	skipFuncs = flSkipFuncs.GetValues()
+
+	errorOut("error", checkFlags())
+
+	pkg, err := Parse(*inputFile, *typeName)
+	errorOut(fmt.Sprintf("error parsing requested type %s", *typeName), err)
+
+	var analysis = struct {
+		InterfaceType string
+		RPCName       string
+		BuildTags     map[string]struct{}
+		*ParsedPkg
+	}{toLower(*typeName), *rpcName, flBuildTags.GetValues(), pkg}
+	var buf bytes.Buffer
+
+	errorOut("parser error", generatedTempl.Execute(&buf, analysis))
+	src, err := format.Source(buf.Bytes())
+	errorOut("error formating generated source", err)
+	errorOut("error writing file", ioutil.WriteFile(*outputFile, src, 0644))
+}
+
+func toLower(s string) string {
+	if s == "" {
+		return ""
+	}
+	r, n := utf8.DecodeRuneInString(s)
+	return string(unicode.ToLower(r)) + s[n:]
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/pluginrpc-gen/parser.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/pluginrpc-gen/parser.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+)
+
+var errBadReturn = errors.New("found return arg with no name: all args must be named")
+
+type errUnexpectedType struct {
+	expected string
+	actual   interface{}
+}
+
+func (e errUnexpectedType) Error() string {
+	return fmt.Sprintf("got wrong type expecting %s, got: %v", e.expected, reflect.TypeOf(e.actual))
+}
+
+// ParsedPkg holds information about a package that has been parsed,
+// its name and the list of functions.
+type ParsedPkg struct {
+	Name      string
+	Functions []function
+}
+
+type function struct {
+	Name    string
+	Args    []arg
+	Returns []arg
+	Doc     string
+}
+
+type arg struct {
+	Name    string
+	ArgType string
+}
+
+func (a *arg) String() string {
+	return a.Name + " " + a.ArgType
+}
+
+// Parse parses the given file for an interface definition with the given name.
+func Parse(filePath string, objName string) (*ParsedPkg, error) {
+	fs := token.NewFileSet()
+	pkg, err := parser.ParseFile(fs, filePath, nil, parser.AllErrors)
+	if err != nil {
+		return nil, err
+	}
+	p := &ParsedPkg{}
+	p.Name = pkg.Name.Name
+	obj, exists := pkg.Scope.Objects[objName]
+	if !exists {
+		return nil, fmt.Errorf("could not find object %s in %s", objName, filePath)
+	}
+	if obj.Kind != ast.Typ {
+		return nil, fmt.Errorf("exected type, got %s", obj.Kind)
+	}
+	spec, ok := obj.Decl.(*ast.TypeSpec)
+	if !ok {
+		return nil, errUnexpectedType{"*ast.TypeSpec", obj.Decl}
+	}
+	iface, ok := spec.Type.(*ast.InterfaceType)
+	if !ok {
+		return nil, errUnexpectedType{"*ast.InterfaceType", spec.Type}
+	}
+
+	p.Functions, err = parseInterface(iface)
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+func parseInterface(iface *ast.InterfaceType) ([]function, error) {
+	var functions []function
+	for _, field := range iface.Methods.List {
+		switch f := field.Type.(type) {
+		case *ast.FuncType:
+			method, err := parseFunc(field)
+			if err != nil {
+				return nil, err
+			}
+			if method == nil {
+				continue
+			}
+			functions = append(functions, *method)
+		case *ast.Ident:
+			spec, ok := f.Obj.Decl.(*ast.TypeSpec)
+			if !ok {
+				return nil, errUnexpectedType{"*ast.TypeSpec", f.Obj.Decl}
+			}
+			iface, ok := spec.Type.(*ast.InterfaceType)
+			if !ok {
+				return nil, errUnexpectedType{"*ast.TypeSpec", spec.Type}
+			}
+			funcs, err := parseInterface(iface)
+			if err != nil {
+				fmt.Println(err)
+				continue
+			}
+			functions = append(functions, funcs...)
+		default:
+			return nil, errUnexpectedType{"*astFuncType or *ast.Ident", f}
+		}
+	}
+	return functions, nil
+}
+
+func parseFunc(field *ast.Field) (*function, error) {
+	f := field.Type.(*ast.FuncType)
+	method := &function{Name: field.Names[0].Name}
+	if _, exists := skipFuncs[method.Name]; exists {
+		fmt.Println("skipping:", method.Name)
+		return nil, nil
+	}
+	if f.Params != nil {
+		args, err := parseArgs(f.Params.List)
+		if err != nil {
+			return nil, err
+		}
+		method.Args = args
+	}
+	if f.Results != nil {
+		returns, err := parseArgs(f.Results.List)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing function returns for %q: %v", method.Name, err)
+		}
+		method.Returns = returns
+	}
+	return method, nil
+}
+
+func parseArgs(fields []*ast.Field) ([]arg, error) {
+	var args []arg
+	for _, f := range fields {
+		if len(f.Names) == 0 {
+			return nil, errBadReturn
+		}
+		for _, name := range f.Names {
+			var typeName string
+			switch argType := f.Type.(type) {
+			case *ast.Ident:
+				typeName = argType.Name
+			case *ast.StarExpr:
+				i, ok := argType.X.(*ast.Ident)
+				if !ok {
+					return nil, errUnexpectedType{"*ast.Ident", f.Type}
+				}
+				typeName = "*" + i.Name
+			default:
+				return nil, errUnexpectedType{"*ast.Ident or *ast.StarExpr", f.Type}
+			}
+
+			args = append(args, arg{name.Name, typeName})
+		}
+	}
+	return args, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/pluginrpc-gen/template.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/pluginrpc-gen/template.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"strings"
+	"text/template"
+)
+
+func printArgs(args []arg) string {
+	var argStr []string
+	for _, arg := range args {
+		argStr = append(argStr, arg.String())
+	}
+	return strings.Join(argStr, ", ")
+}
+
+func marshalType(t string) string {
+	switch t {
+	case "error":
+		// convert error types to plain strings to ensure the values are encoded/decoded properly
+		return "string"
+	default:
+		return t
+	}
+}
+
+func isErr(t string) bool {
+	switch t {
+	case "error":
+		return true
+	default:
+		return false
+	}
+}
+
+// Need to use this helper due to issues with go-vet
+func buildTag(s string) string {
+	return "+build " + s
+}
+
+var templFuncs = template.FuncMap{
+	"printArgs":   printArgs,
+	"marshalType": marshalType,
+	"isErr":       isErr,
+	"lower":       strings.ToLower,
+	"title":       strings.Title,
+	"tag":         buildTag,
+}
+
+var generatedTempl = template.Must(template.New("rpc_cient").Funcs(templFuncs).Parse(`
+// generated code - DO NOT EDIT
+{{ range $k, $v := .BuildTags }}
+	// {{ tag $k }} {{ end }}
+
+package {{ .Name }}
+
+import "errors"
+
+type client interface{
+	Call(string, interface{}, interface{}) error
+}
+
+type {{ .InterfaceType }}Proxy struct {
+	client
+}
+
+{{ range .Functions }}
+	type {{ $.InterfaceType }}Proxy{{ .Name }}Request struct{
+		{{ range .Args }}
+			{{ title .Name }} {{ .ArgType }} {{ end }}
+	}
+
+	type {{ $.InterfaceType }}Proxy{{ .Name }}Response struct{
+		{{ range .Returns }}
+			{{ title .Name }} {{ marshalType .ArgType }} {{ end }}
+	}
+
+	func (pp *{{ $.InterfaceType }}Proxy) {{ .Name }}({{ printArgs .Args }}) ({{ printArgs .Returns }}) {
+		var(
+			req {{ $.InterfaceType }}Proxy{{ .Name }}Request
+			ret {{ $.InterfaceType }}Proxy{{ .Name }}Response
+		)
+		{{ range .Args }}
+			req.{{ title .Name }} = {{ lower .Name }} {{ end }}
+		if err = pp.Call("{{ $.RPCName }}.{{ .Name }}", req, &ret); err != nil {
+			return
+		}
+		{{ range $r := .Returns }}
+			{{ if isErr .ArgType }}
+				if ret.{{ title .Name }} != "" {
+					{{ lower .Name }} = errors.New(ret.{{ title .Name }})
+				} {{ end }}
+			{{ if isErr .ArgType | not }} {{ lower .Name }} = ret.{{ title .Name }} {{ end }} {{ end }}
+
+		return
+	}
+{{ end }}
+`))

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/plugins.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/plugins.go
@@ -1,0 +1,257 @@
+// Package plugins provides structures and helper functions to manage Docker
+// plugins.
+//
+// Docker discovers plugins by looking for them in the plugin directory whenever
+// a user or container tries to use one by name. UNIX domain socket files must
+// be located under /run/docker/plugins, whereas spec files can be located
+// either under /etc/docker/plugins or /usr/lib/docker/plugins. This is handled
+// by the Registry interface, which lets you list all plugins or get a plugin by
+// its name if it exists.
+//
+// The plugins need to implement an HTTP server and bind this to the UNIX socket
+// or the address specified in the spec files.
+// A handshake is send at /Plugin.Activate, and plugins are expected to return
+// a Manifest with a list of of Docker subsystems which this plugin implements.
+//
+// In order to use a plugins, you can use the ``Get`` with the name of the
+// plugin and the subsystem it implements.
+//
+//	plugin, err := plugins.Get("example", "VolumeDriver")
+//	if err != nil {
+//		return fmt.Errorf("Error looking up volume plugin example: %v", err)
+//	}
+package plugins
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/go-connections/tlsconfig"
+)
+
+var (
+	// ErrNotImplements is returned if the plugin does not implement the requested driver.
+	ErrNotImplements = errors.New("Plugin does not implement the requested driver")
+)
+
+type plugins struct {
+	sync.Mutex
+	plugins map[string]*Plugin
+}
+
+var (
+	storage          = plugins{plugins: make(map[string]*Plugin)}
+	extpointHandlers = make(map[string]func(string, *Client))
+)
+
+// Manifest lists what a plugin implements.
+type Manifest struct {
+	// List of subsystem the plugin implements.
+	Implements []string
+}
+
+// Plugin is the definition of a docker plugin.
+type Plugin struct {
+	// Name of the plugin
+	Name string `json:"-"`
+	// Address of the plugin
+	Addr string
+	// TLS configuration of the plugin
+	TLSConfig tlsconfig.Options
+	// Client attached to the plugin
+	Client *Client `json:"-"`
+	// Manifest of the plugin (see above)
+	Manifest *Manifest `json:"-"`
+
+	// error produced by activation
+	activateErr error
+	// specifies if the activation sequence is completed (not if it is sucessful or not)
+	activated bool
+	// wait for activation to finish
+	activateWait *sync.Cond
+}
+
+func newLocalPlugin(name, addr string) *Plugin {
+	return &Plugin{
+		Name:         name,
+		Addr:         addr,
+		TLSConfig:    tlsconfig.Options{InsecureSkipVerify: true},
+		activateWait: sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+func (p *Plugin) activate() error {
+	p.activateWait.L.Lock()
+	if p.activated {
+		p.activateWait.L.Unlock()
+		return p.activateErr
+	}
+
+	p.activateErr = p.activateWithLock()
+	p.activated = true
+
+	p.activateWait.L.Unlock()
+	p.activateWait.Broadcast()
+	return p.activateErr
+}
+
+func (p *Plugin) activateWithLock() error {
+	c, err := NewClient(p.Addr, p.TLSConfig)
+	if err != nil {
+		return err
+	}
+	p.Client = c
+
+	m := new(Manifest)
+	if err = p.Client.Call("Plugin.Activate", nil, m); err != nil {
+		return err
+	}
+
+	p.Manifest = m
+
+	for _, iface := range m.Implements {
+		handler, handled := extpointHandlers[iface]
+		if !handled {
+			continue
+		}
+		handler(p.Name, p.Client)
+	}
+	return nil
+}
+
+func (p *Plugin) waitActive() error {
+	p.activateWait.L.Lock()
+	for !p.activated {
+		p.activateWait.Wait()
+	}
+	p.activateWait.L.Unlock()
+	return p.activateErr
+}
+
+func (p *Plugin) implements(kind string) bool {
+	if err := p.waitActive(); err != nil {
+		return false
+	}
+	for _, driver := range p.Manifest.Implements {
+		if driver == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func load(name string) (*Plugin, error) {
+	return loadWithRetry(name, true)
+}
+
+func loadWithRetry(name string, retry bool) (*Plugin, error) {
+	registry := newLocalRegistry()
+	start := time.Now()
+
+	var retries int
+	for {
+		pl, err := registry.Plugin(name)
+		if err != nil {
+			if !retry {
+				return nil, err
+			}
+
+			timeOff := backoff(retries)
+			if abort(start, timeOff) {
+				return nil, err
+			}
+			retries++
+			logrus.Warnf("Unable to locate plugin: %s, retrying in %v", name, timeOff)
+			time.Sleep(timeOff)
+			continue
+		}
+
+		storage.Lock()
+		storage.plugins[name] = pl
+		storage.Unlock()
+
+		err = pl.activate()
+
+		if err != nil {
+			storage.Lock()
+			delete(storage.plugins, name)
+			storage.Unlock()
+		}
+
+		return pl, err
+	}
+}
+
+func get(name string) (*Plugin, error) {
+	storage.Lock()
+	pl, ok := storage.plugins[name]
+	storage.Unlock()
+	if ok {
+		return pl, pl.activate()
+	}
+	return load(name)
+}
+
+// Get returns the plugin given the specified name and requested implementation.
+func Get(name, imp string) (*Plugin, error) {
+	pl, err := get(name)
+	if err != nil {
+		return nil, err
+	}
+	if pl.implements(imp) {
+		logrus.Debugf("%s implements: %s", name, imp)
+		return pl, nil
+	}
+	return nil, ErrNotImplements
+}
+
+// Handle adds the specified function to the extpointHandlers.
+func Handle(iface string, fn func(string, *Client)) {
+	extpointHandlers[iface] = fn
+}
+
+// GetAll returns all the plugins for the specified implementation
+func GetAll(imp string) ([]*Plugin, error) {
+	pluginNames, err := Scan()
+	if err != nil {
+		return nil, err
+	}
+
+	type plLoad struct {
+		pl  *Plugin
+		err error
+	}
+
+	chPl := make(chan *plLoad, len(pluginNames))
+	var wg sync.WaitGroup
+	for _, name := range pluginNames {
+		if pl, ok := storage.plugins[name]; ok {
+			chPl <- &plLoad{pl, nil}
+			continue
+		}
+
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			pl, err := loadWithRetry(name, false)
+			chPl <- &plLoad{pl, err}
+		}(name)
+	}
+
+	wg.Wait()
+	close(chPl)
+
+	var out []*Plugin
+	for pl := range chPl {
+		if pl.err != nil {
+			logrus.Error(pl.err)
+			continue
+		}
+		if pl.pl.implements(imp) {
+			out = append(out, pl.pl)
+		}
+	}
+	return out, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/transport/http.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/transport/http.go
@@ -1,0 +1,36 @@
+package transport
+
+import (
+	"io"
+	"net/http"
+)
+
+// httpTransport holds an http.RoundTripper
+// and information about the scheme and address the transport
+// sends request to.
+type httpTransport struct {
+	http.RoundTripper
+	scheme string
+	addr   string
+}
+
+// NewHTTPTransport creates a new httpTransport.
+func NewHTTPTransport(r http.RoundTripper, scheme, addr string) Transport {
+	return httpTransport{
+		RoundTripper: r,
+		scheme:       scheme,
+		addr:         addr,
+	}
+}
+
+// NewRequest creates a new http.Request and sets the URL
+// scheme and address with the transport's fields.
+func (t httpTransport) NewRequest(path string, data io.Reader) (*http.Request, error) {
+	req, err := newHTTPRequest(path, data)
+	if err != nil {
+		return nil, err
+	}
+	req.URL.Scheme = t.scheme
+	req.URL.Host = t.addr
+	return req, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/transport/transport.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/plugins/transport/transport.go
@@ -1,0 +1,36 @@
+package transport
+
+import (
+	"io"
+	"net/http"
+	"strings"
+)
+
+// VersionMimetype is the Content-Type the engine sends to plugins.
+const VersionMimetype = "application/vnd.docker.plugins.v1.2+json"
+
+// RequestFactory defines an interface that
+// transports can implement to create new requests.
+type RequestFactory interface {
+	NewRequest(path string, data io.Reader) (*http.Request, error)
+}
+
+// Transport defines an interface that plugin transports
+// must implement.
+type Transport interface {
+	http.RoundTripper
+	RequestFactory
+}
+
+// newHTTPRequest creates a new request with a path and a body.
+func newHTTPRequest(path string, data io.Reader) (*http.Request, error) {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	req, err := http.NewRequest("POST", path, data)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", VersionMimetype)
+	return req, nil
+}

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -29,7 +29,7 @@ var (
 				flRefreshIntervalMin, flRefreshIntervalMax, flFailureRetry, flRefreshRetry,
 				flHeartBeat,
 				flEnableCors,
-				flCluster, flDiscoveryOpt, flClusterOpt},
+				flCluster, flDiscoveryOpt, flClusterOpt, flAuthorizationPlugins},
 			Action: manage,
 		},
 		{

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -151,4 +151,9 @@ var (
 		Value: "20s",
 		Usage: "Leader lock release time on failure",
 	}
+	flAuthorizationPlugins = cli.StringSliceFlag{
+		Name:  "authorization-plugin",
+		Usage: "List authorization plugins in order from first evaluator to last",
+		Value: &cli.StringSlice{},
+	}
 )

--- a/cli/manage.go
+++ b/cli/manage.go
@@ -143,7 +143,7 @@ func setupReplication(c *cli.Context, cluster cluster.Cluster, server *api.Serve
 	candidate := leadership.NewCandidate(client, p, addr, leaderTTL)
 	follower := leadership.NewFollower(client, p)
 
-	primary := api.NewPrimary(cluster, tlsConfig, &statusHandler{cluster, candidate, follower}, c.GlobalBool("debug"), c.Bool("cors"))
+	primary := api.NewPrimary(cluster, tlsConfig, &statusHandler{cluster, candidate, follower}, c.GlobalBool("debug"), c.Bool("cors"), c.GlobalStringSlice("authorization-plugin"))
 	replica := api.NewReplica(primary, tlsConfig)
 
 	go func() {
@@ -321,7 +321,7 @@ func manage(c *cli.Context) {
 
 		setupReplication(c, cl, server, discovery, addr, leaderTTL, tlsConfig)
 	} else {
-		server.SetHandler(api.NewPrimary(cl, tlsConfig, &statusHandler{cl, nil, nil}, c.GlobalBool("debug"), c.Bool("cors")))
+		server.SetHandler(api.NewPrimary(cl, tlsConfig, &statusHandler{cl, nil, nil}, c.GlobalBool("debug"), c.Bool("cors"), c.StringSlice("authorization-plugin")))
 		cluster.NewWatchdog(cl)
 	}
 

--- a/main.go
+++ b/main.go
@@ -10,5 +10,6 @@ import (
 )
 
 func main() {
+	//Test
 	cli.Run()
 }


### PR DESCRIPTION
 ACLs in Swarm see #1199 #1365 

Authorization (ACLs) support in Swarm as a first step towards multi tenancy. #1199

This PR includes (organized by Commits for convenience)

1 - Validation API & Default implementation- Approve/Disapprove/condition of 'Who wants to to what'?
2 - Handler API & Default implementation - Use labels to enforce decision of 1
3 - Feature flag --multiTenant to get this feature going (regular Swarm otherwise) 

(Re open PR for internal PM reasons)
