### PR TITLE
Remove swarm container skipping

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -376,8 +376,10 @@ func getContainersJSON(c *context, w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Skip swarm containers unless -a was specified.
-		if strings.Split(container.Image, ":")[0] == "swarm" && !all {
-			continue
+		if value, exists := container.Config.Labels["com.docker.swarm.hidden"]; exists {
+			if value == "true" && !all {
+				continue
+			}
 		}
 
 		// Apply filters.


### PR DESCRIPTION
Fixes #1827 
Remove swarm container skipping.
As this part of codes will not work if swarm image is store in a private resgistry,
inconsistency will happen when using same code in different environment.

Signed-off-by: Sun Hongliang allen.sun@daocloud.io
