### PR TITLE
validate cluster-opt and log error when incorrect format

### DIFF
--- a/cluster/mesos/cluster_options.go
+++ b/cluster/mesos/cluster_options.go
@@ -1,0 +1,98 @@
+package mesos
+
+import (
+	"net"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/swarm/cluster"
+	mesosscheduler "github.com/mesos/mesos-go/scheduler"
+)
+
+// parseDriveConfig parses cluster opts to fill some fields of mesosscheduler.DriverConfig
+func parseDriveConfig(options cluster.DriverOpts, driverConfig *mesosscheduler.DriverConfig) {
+	if bindingPort, err := options.Uint("mesos.port", "SWARM_MESOS_PORT"); err != nil {
+		if err == cluster.ErrNoKeyNorEnv {
+			log.Debug("no mesos.port in cluster-opts nor SWARM_MESOS_PORT in env")
+		} else {
+			log.Fatalf("Failed to parse mesos.port in Uint (%v)", err)
+		}
+	} else {
+		// validate bindingPort to be a valid BindingPort
+		if uint16(bindingPort) == 0 {
+			log.Fatal("mesos.port cannot be 0")
+		}
+		driverConfig.BindingPort = uint16(bindingPort)
+	}
+
+	if bindingAddress, err := options.String("mesos.address", "SWARM_MESOS_ADDRESS"); err != nil {
+		log.Debug("no mesos.address in cluster-opts nor SWARM_MESOS_ADDRESS in env")
+	} else {
+		if ipAddress := net.ParseIP(bindingAddress); ipAddress == nil {
+			log.Fatalf("invalid IP address for cluster-opt mesos.address: %s", bindingAddress)
+		} else {
+			driverConfig.BindingAddress = ipAddress
+		}
+	}
+
+	if checkpointFailover, err := options.Bool("mesos.checkpointfailover", "SWARM_MESOS_CHECKPOINT_FAILOVER"); err != nil {
+		if err == cluster.ErrNoKeyNorEnv {
+			log.Debug("no mesos.checkpointfailover in cluster-opts nor SWARM_MESOS_CHECKPOINT_FAILOVER in env")
+		} else {
+			log.Fatalf("Failed to parse mesos.checkpointfailover in Bool (%v)", err)
+		}
+	} else {
+		driverConfig.Framework.Checkpoint = &checkpointFailover
+	}
+}
+
+// parseClusterOpts parses cluster-opt to fill some fields of mesos.Cluster
+func parseClusterOpts(options cluster.DriverOpts, cl *Cluster) {
+	if taskCreationTimeout, err := options.String("mesos.tasktimeout", "SWARM_MESOS_TASK_TIMEOUT"); err != nil {
+		if err == cluster.ErrNoKeyNorEnv {
+			log.Debug("no mesos.tasktimeout in cluster-opts nor SWARM_MESOS_TASK_TIMEOUT in env")
+		}
+	} else {
+		d, err := time.ParseDuration(taskCreationTimeout)
+		if err != nil {
+			log.Fatalf("Failed to parse mesos.tasktimeout in Duration (%v)", err)
+		}
+		// validate d to be a valid taskCreationTimeout
+		if d < time.Duration(0)*time.Second {
+			log.Fatalf("mesos.taskCreationTimeout cannot be a negative number")
+		}
+		cl.taskCreationTimeout = d
+	}
+
+	if offerTimeout, err := options.String("mesos.offertimeout", "SWARM_MESOS_OFFER_TIMEOUT"); err != nil {
+		if err == cluster.ErrNoKeyNorEnv {
+			log.Debug("no mesos.offertimeout in cluster-opts nor SWARM_MESOS_OFFER_TIMEOUT in env")
+		}
+	} else {
+		d, err := time.ParseDuration(offerTimeout)
+		if err != nil {
+			log.Fatalf("Failed to parse mesos.offertimeout in Duration (%v)", err)
+		}
+		// validate d to be a valid offerTimeout
+		if d < time.Duration(0)*time.Second {
+			log.Fatalf("mesos.offerTimeout cannot be a negative number")
+		}
+		cl.offerTimeout = d
+	}
+
+	if refuseTimeout, err := options.String("mesos.offerrefusetimeout", "SWARM_MESOS_OFFER_REFUSE_TIMEOUT"); err != nil {
+		if err == cluster.ErrNoKeyNorEnv {
+			log.Debug("no mesos.offerrefusetimeout in cluster-opts nor SWARM_MESOS_OFFER_REFUSE_TIMEOUT in env")
+		}
+	} else {
+		d, err := time.ParseDuration(refuseTimeout)
+		if err != nil {
+			log.Fatalf("Failed to parse mesos.offerrefusetimeout in Duration (%v)", err)
+		}
+		// validate d to be a valid offerrefusetimeout
+		if d < time.Duration(0)*time.Second {
+			log.Fatalf("mesos.offerrefusetimeout cannot be a negative number")
+		}
+		cl.refuseTimeout = d
+	}
+}

--- a/cluster/options.go
+++ b/cluster/options.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -10,60 +11,85 @@ import (
 // DriverOpts are key=values options
 type DriverOpts []string
 
+// ErrNoKeyNorEnv is exported
+var ErrNoKeyNorEnv = fmt.Errorf("No key in options and no env")
+
 // String returns a string from the driver options
-func (do DriverOpts) String(key, env string) (string, bool) {
+func (do DriverOpts) String(key, env string) (string, error) {
 	for _, opt := range do {
 		kv := strings.SplitN(opt, "=", 2)
 		if kv[0] == key {
-			return kv[1], true
+			return kv[1], nil
 		}
 	}
 	if env := os.Getenv(env); env != "" {
-		return env, true
+		return env, nil
 	}
-	return "", false
+	return "", ErrNoKeyNorEnv
 }
 
 // Int returns an int64 from the driver options
-func (do DriverOpts) Int(key, env string) (int64, bool) {
-	if value, ok := do.String(key, env); ok {
-		v, _ := strconv.ParseInt(value, 0, 64)
-		return v, true
+func (do DriverOpts) Int(key, env string) (int64, error) {
+	value, err := do.String(key, env)
+	if err != nil {
+		return 0, err
 	}
-	return 0, false
+
+	v, err := strconv.ParseInt(value, 0, 64)
+	if err != nil {
+		return 0, err
+	}
+	return v, nil
 }
 
 // Uint returns an int64 from the driver options
-func (do DriverOpts) Uint(key, env string) (uint64, bool) {
-	if value, ok := do.String(key, env); ok {
-		v, _ := strconv.ParseUint(value, 0, 64)
-		return v, true
+func (do DriverOpts) Uint(key, env string) (uint64, error) {
+	value, err := do.String(key, env)
+	if err != nil {
+		return 0, err
 	}
-	return 0, false
+
+	v, err := strconv.ParseUint(value, 0, 64)
+	if err != nil {
+		return 0, err
+	}
+	return v, nil
 }
 
 // Float returns a float64 from the driver options
-func (do DriverOpts) Float(key, env string) (float64, bool) {
-	if value, ok := do.String(key, env); ok {
-		v, _ := strconv.ParseFloat(value, 64)
-		return v, true
+func (do DriverOpts) Float(key, env string) (float64, error) {
+	value, err := do.String(key, env)
+	if err != nil {
+		return 0.0, err
 	}
-	return 0.0, false
+
+	v, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0.0, err
+	}
+	return v, nil
+
 }
 
 // IP returns an IP address from the driver options
-func (do DriverOpts) IP(key, env string) (net.IP, bool) {
-	if value, ok := do.String(key, env); ok {
-		return net.ParseIP(value), true
+func (do DriverOpts) IP(key, env string) (net.IP, error) {
+	value, err := do.String(key, env)
+	if err != nil {
+		return nil, err
 	}
-	return nil, false
+	return net.ParseIP(value), nil
 }
 
-// Bool returns a boolean from the driver options
-func (do DriverOpts) Bool(key, env string) (bool, bool) {
-	if value, ok := do.String(key, env); ok {
-		b, _ := strconv.ParseBool(value)
-		return b, true
+// Bool returns a errorean from the driver options
+func (do DriverOpts) Bool(key, env string) (bool, error) {
+	value, err := do.String(key, env)
+	if err != nil {
+		return false, err
 	}
-	return false, false
+
+	b, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, err
+	}
+	return b, nil
 }

--- a/cluster/options_test.go
+++ b/cluster/options_test.go
@@ -8,147 +8,370 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var opts = DriverOpts{"foo1=bar", "foo2=-5", "foo3=7", "foo4=0.6", "foo5=127.0.0.1"}
+var opts = DriverOpts{
+	"foo1=bar",
+	"foo2=-5",
+	"foo3=-5ss",
+	"foo4=7",
+	"foo5=7ss",
+	"foo6=0.6",
+	"foo7=0.6ss",
+	"foo8=127.0.0.1",
+	"foo9=127.0.0.1oo",
+	"foo10=true",
+	"foo11=truess",
+}
 
 func TestString(t *testing.T) {
-	if err := os.Setenv("FOO_4", "bar"); err != nil {
+	if err := os.Setenv("FOO_12", "bar"); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Unsetenv("FOO_4")
+	defer os.Unsetenv("FOO_12")
 
-	val, ok := opts.String("foo1", "")
-	assert.True(t, ok)
+	val, err := opts.String("foo1", "")
+	assert.Nil(t, err)
 	assert.Equal(t, val, "bar")
 
-	val, ok = opts.String("foo2", "")
-	assert.True(t, ok)
+	val, err = opts.String("foo2", "")
+	assert.Nil(t, err)
 	assert.Equal(t, val, "-5")
 
-	val, ok = opts.String("foo3", "")
-	assert.True(t, ok)
+	val, err = opts.String("foo3", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, "-5ss")
+
+	val, err = opts.String("foo4", "")
+	assert.Nil(t, err)
 	assert.Equal(t, val, "7")
 
-	val, ok = opts.String("foo4", "")
-	assert.True(t, ok)
+	val, err = opts.String("foo5", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, "7ss")
+
+	val, err = opts.String("foo6", "")
+	assert.Nil(t, err)
 	assert.Equal(t, val, "0.6")
 
-	val, ok = opts.String("", "FOO_4")
-	assert.True(t, ok)
+	val, err = opts.String("foo7", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, "0.6ss")
+
+	val, err = opts.String("foo8", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, "127.0.0.1")
+
+	val, err = opts.String("foo9", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, "127.0.0.1oo")
+
+	val, err = opts.String("foo10", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, "true")
+
+	val, err = opts.String("foo11", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, "truess")
+
+	val, err = opts.String("", "FOO_12")
+	assert.Nil(t, err)
 	assert.Equal(t, val, "bar")
 
-	val, ok = opts.String("invalid", "")
-	assert.False(t, ok)
+	val, err = opts.String("invalid", "")
+	assert.NotNil(t, err)
 	assert.Equal(t, val, "")
 }
 
 func TestInt(t *testing.T) {
-	if err := os.Setenv("FOO_4", "bar"); err != nil {
+	if err := os.Setenv("FOO_12", "bar"); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Unsetenv("FOO_4")
+	defer os.Unsetenv("FOO_12")
 
-	val, ok := opts.Int("foo1", "")
-	assert.True(t, ok)
+	val, err := opts.Int("foo1", "")
+	assert.NotNil(t, err)
 	assert.Equal(t, val, int64(0))
 
-	val, ok = opts.Int("foo2", "")
-	assert.True(t, ok)
+	val, err = opts.Int("foo2", "")
+	assert.Nil(t, err)
 	assert.Equal(t, val, int64(-5))
 
-	val, ok = opts.Int("foo3", "")
-	assert.True(t, ok)
+	val, err = opts.Int("foo3", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, int64(0))
+
+	val, err = opts.Int("foo4", "")
+	assert.Nil(t, err)
 	assert.Equal(t, val, int64(7))
 
-	val, ok = opts.Int("foo4", "")
-	assert.True(t, ok)
+	val, err = opts.Int("foo5", "")
+	assert.NotNil(t, err)
 	assert.Equal(t, val, int64(0))
 
-	val, ok = opts.Int("", "FOO_4")
-	assert.True(t, ok)
+	val, err = opts.Int("foo6", "")
+	assert.NotNil(t, err)
 	assert.Equal(t, val, int64(0))
 
-	val, ok = opts.Int("invalid", "")
-	assert.False(t, ok)
+	val, err = opts.Int("foo7", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, int64(0))
+
+	val, err = opts.Int("foo8", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, int64(0))
+
+	val, err = opts.Int("foo9", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, int64(0))
+
+	val, err = opts.Int("foo10", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, int64(0))
+
+	val, err = opts.Int("foo11", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, int64(0))
+
+	val, err = opts.Int("", "FOO_12")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, int64(0))
+
+	val, err = opts.Int("invalid", "")
+	assert.NotNil(t, err)
 	assert.Equal(t, val, int64(0))
 }
 
 func TestUint(t *testing.T) {
-	if err := os.Setenv("FOO_4", "bar"); err != nil {
+	if err := os.Setenv("FOO_12", "bar"); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Unsetenv("FOO_4")
+	defer os.Unsetenv("FOO_12")
 
-	val, ok := opts.Uint("foo1", "")
-	assert.True(t, ok)
+	val, err := opts.Uint("foo1", "")
+	assert.NotNil(t, err)
 	assert.Equal(t, val, uint64(0))
 
-	val, ok = opts.Uint("foo2", "")
-	assert.True(t, ok)
+	val, err = opts.Uint("foo2", "")
+	assert.NotNil(t, err)
 	assert.Equal(t, val, uint64(0))
 
-	val, ok = opts.Uint("foo3", "")
-	assert.True(t, ok)
+	val, err = opts.Uint("foo3", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, uint64(0))
+
+	val, err = opts.Uint("foo4", "")
+	assert.Nil(t, err)
 	assert.Equal(t, val, uint64(7))
 
-	val, ok = opts.Uint("foo4", "")
-	assert.True(t, ok)
+	val, err = opts.Uint("foo5", "")
+	assert.NotNil(t, err)
 	assert.Equal(t, val, uint64(0))
 
-	val, ok = opts.Uint("", "FOO_4")
-	assert.True(t, ok)
+	val, err = opts.Uint("foo6", "")
+	assert.NotNil(t, err)
 	assert.Equal(t, val, uint64(0))
 
-	val, ok = opts.Uint("invalid", "")
-	assert.False(t, ok)
+	val, err = opts.Uint("foo7", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, uint64(0))
+
+	val, err = opts.Uint("foo8", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, uint64(0))
+
+	val, err = opts.Uint("foo9", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, uint64(0))
+
+	val, err = opts.Uint("foo10", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, uint64(0))
+
+	val, err = opts.Uint("foo11", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, uint64(0))
+
+	val, err = opts.Uint("", "FOO_12")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, uint64(0))
+
+	val, err = opts.Uint("invalid", "")
+	assert.NotNil(t, err)
 	assert.Equal(t, val, uint64(0))
 }
 
 func TestFloat(t *testing.T) {
-	if err := os.Setenv("FOO_4", "0.2"); err != nil {
+	if err := os.Setenv("FOO_12", "0.2"); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Unsetenv("FOO_4")
+	defer os.Unsetenv("FOO_12")
 
-	val, ok := opts.Float("foo1", "")
-	assert.True(t, ok)
+	val, err := opts.Float("foo1", "")
+	assert.NotNil(t, err)
 	assert.Equal(t, val, 0.0)
 
-	val, ok = opts.Float("foo2", "")
-	assert.True(t, ok)
+	val, err = opts.Float("foo2", "")
+	assert.Nil(t, err)
 	assert.Equal(t, val, -5.0)
 
-	val, ok = opts.Float("foo3", "")
-	assert.True(t, ok)
+	val, err = opts.Float("foo3", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, 0.0)
+
+	val, err = opts.Float("foo4", "")
+	assert.Nil(t, err)
 	assert.Equal(t, val, 7.0)
 
-	val, ok = opts.Float("foo4", "")
-	assert.True(t, ok)
+	val, err = opts.Float("foo5", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, 0.0)
+
+	val, err = opts.Float("foo6", "")
+	assert.Nil(t, err)
 	assert.Equal(t, val, 0.6)
 
-	val, ok = opts.Float("", "FOO_4")
-	assert.True(t, ok)
+	val, err = opts.Float("foo7", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, 0.0)
+
+	val, err = opts.Float("foo8", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, 0.0)
+
+	val, err = opts.Float("foo9", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, 0.0)
+
+	val, err = opts.Float("foo10", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, 0.0)
+
+	val, err = opts.Float("foo11", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, 0.0)
+
+	val, err = opts.Float("", "FOO_12")
+	assert.Nil(t, err)
 	assert.Equal(t, val, 0.2)
 
-	val, ok = opts.Float("invalid", "")
-	assert.False(t, ok)
+	val, err = opts.Float("invalid", "")
+	assert.NotNil(t, err)
 	assert.Equal(t, val, 0.0)
 }
 
 func TestIP(t *testing.T) {
-	if err := os.Setenv("FOO_4", "0.0.0.0"); err != nil {
+	if err := os.Setenv("FOO_12", "0.0.0.0"); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Unsetenv("FOO_4")
+	defer os.Unsetenv("FOO_12")
 
-	val, ok := opts.IP("foo5", "")
-	assert.True(t, ok)
+	val, err := opts.IP("foo1", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, net.ParseIP(""))
+
+	val, err = opts.IP("foo2", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, net.ParseIP(""))
+
+	val, err = opts.IP("foo3", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, net.ParseIP(""))
+
+	val, err = opts.IP("foo4", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, net.ParseIP(""))
+
+	val, err = opts.IP("foo5", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, net.ParseIP(""))
+
+	val, err = opts.IP("foo6", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, net.ParseIP(""))
+
+	val, err = opts.IP("foo7", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, net.ParseIP(""))
+
+	val, err = opts.IP("foo8", "")
+	assert.Nil(t, err)
 	assert.Equal(t, val, net.ParseIP("127.0.0.1"))
 
-	val, ok = opts.IP("", "FOO_4")
-	assert.True(t, ok)
+	val, err = opts.IP("foo9", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, net.ParseIP(""))
+
+	val, err = opts.IP("foo10", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, net.ParseIP(""))
+
+	val, err = opts.IP("foo11", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, net.ParseIP(""))
+
+	val, err = opts.IP("", "FOO_12")
+	assert.Nil(t, err)
 	assert.Equal(t, val, net.ParseIP("0.0.0.0"))
 
-	val, ok = opts.IP("invalid", "")
-	assert.False(t, ok)
-	assert.Equal(t, val, net.IP(nil))
+	val, err = opts.IP("invalid", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, net.ParseIP(""))
+}
+
+func TestBool(t *testing.T) {
+	if err := os.Setenv("FOO_12", "true"); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Unsetenv("FOO_12")
+
+	val, err := opts.Bool("foo1", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, false)
+
+	val, err = opts.Bool("foo2", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, false)
+
+	val, err = opts.Bool("foo3", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, false)
+
+	val, err = opts.Bool("foo4", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, false)
+
+	val, err = opts.Bool("foo5", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, false)
+
+	val, err = opts.Bool("foo6", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, false)
+
+	val, err = opts.Bool("foo7", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, false)
+
+	val, err = opts.Bool("foo8", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, false)
+
+	val, err = opts.Bool("foo9", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, false)
+
+	val, err = opts.Bool("foo10", "")
+	assert.Nil(t, err)
+	assert.Equal(t, val, true)
+
+	val, err = opts.Bool("foo11", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, false)
+
+	val, err = opts.Bool("", "FOO_12")
+	assert.Nil(t, err)
+	assert.Equal(t, val, true)
+
+	val, err = opts.Bool("invalid", "")
+	assert.NotNil(t, err)
+	assert.Equal(t, val, false)
 }

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -86,23 +86,7 @@ func NewCluster(scheduler *scheduler.Scheduler, TLSConfig *tls.Config, discovery
 		createRetry:       0,
 	}
 
-	if val, ok := options.Float("swarm.overcommit", ""); ok {
-		if val <= float64(-1) {
-			log.Fatalf("swarm.overcommit should be larger than -1, %f is invalid", val)
-		} else if val < float64(0) {
-			log.Warn("-1 < swarm.overcommit < 0 will make swarm take less resource than docker engine offers")
-			cluster.overcommitRatio = val
-		} else {
-			cluster.overcommitRatio = val
-		}
-	}
-
-	if val, ok := options.Int("swarm.createretry", ""); ok {
-		if val < 0 {
-			log.Fatalf("swarm.createretry can not be negative, %d is invalid", val)
-		}
-		cluster.createRetry = val
-	}
+	parseClusterOpts(options, cluster)
 
 	discoveryCh, errCh := cluster.discovery.Watch(nil)
 	go cluster.monitorDiscovery(discoveryCh, errCh)

--- a/cluster/swarm/cluster_options.go
+++ b/cluster/swarm/cluster_options.go
@@ -1,0 +1,47 @@
+package swarm
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/swarm/cluster"
+)
+
+// parseClusterOpts parses cluster opts to fill some fields of swarm.Cluster
+func parseClusterOpts(options cluster.DriverOpts, cl *Cluster) {
+	// parse swarm.overcommit in cluster-opt
+	if val, err := options.Float("swarm.overcommit", ""); err != nil {
+		// run into error when parsing swarm.overcommit
+		if err == cluster.ErrNoKeyNorEnv {
+			// swarm.overcommit is not provided, just move on
+			log.Debug("swarm.overcommit is not provided in cluster options")
+		} else {
+			log.Fatalf("Failed to parse swarm.overcommit in Float (%v)", err)
+		}
+	} else {
+		//validate val to be a valid overcommit
+		if val <= float64(-1) {
+			log.Fatalf("swarm.overcommit should be larger than -1, %f is invalid", val)
+		} else if val < float64(0) {
+			log.Warn("-1 < swarm.overcommit < 0 will make swarm take less resource than docker engine offers")
+			cl.overcommitRatio = val
+		} else {
+			cl.overcommitRatio = val
+		}
+	}
+
+	// parse swarm.createretry in cluster-opt
+	if val, err := options.Int("swarm.createretry", ""); err != nil {
+		// run into error when parsing swarm.createretry
+		if err == cluster.ErrNoKeyNorEnv {
+			// swarm.createretry is not provided, just move on
+			log.Debug("swarm.createretry is not provided in cluster options")
+		} else {
+			log.Fatalf("Failed to parse swarm.createretry in Int (%v)", err)
+		}
+	} else {
+		//validate val to be a valid createRetry
+		if val < 0 {
+			log.Fatalf("swarm.createretry can not be negative, %d is invalid", val)
+		}
+		cl.createRetry = val
+	}
+}

--- a/test/integration/mesos/cluster_options.bats
+++ b/test/integration/mesos/cluster_options.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+load ../../helpers
+load ../mesos_helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_mesos
+	stop_docker
+}
+
+@test "swarm - cluster options" {
+	start_docker 2
+	start_mesos
+
+	# mesos.port in cluster-opt
+	run swarm manage --cluster-driver mesos-experimental --cluster-opt mesos.port=123asd 127.0.0.1:$MESOS_MASTER_PORT
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"Failed to parse mesos.port in Uint"* ]]
+
+	run swarm manage --cluster-driver mesos-experimental --cluster-opt mesos.port=0 127.0.0.1:$MESOS_MASTER_PORT
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"mesos.port cannot be 0"* ]]
+
+	# mesos.address in cluster-opt
+	run swarm manage --cluster-driver mesos-experimental --cluster-opt mesos.address=127.0.0.1oooo 127.0.0.1:$MESOS_MASTER_PORT
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"invalid IP address for cluster-opt mesos.address:"* ]]
+
+	# mesos.checkpointfailover in cluster-opt
+	run swarm manage --cluster-driver mesos-experimental --cluster-opt mesos.checkpointfailover=123asd 127.0.0.1:$MESOS_MASTER_PORT
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"Failed to parse mesos.checkpointfailover in Bool"* ]]
+
+	# mesos.tasktimeout in cluster-opt
+	run swarm manage --cluster-driver mesos-experimental --cluster-opt mesos.tasktimeout=123asd 127.0.0.1:$MESOS_MASTER_PORT
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"Failed to parse mesos.tasktimeout in Duration"* ]]
+
+	run swarm manage --cluster-driver mesos-experimental --cluster-opt mesos.tasktimeout=-1 127.0.0.1:$MESOS_MASTER_PORT
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"mesos.taskCreationTimeout cannot be a negative number"* ]]
+
+	# mesos.offertimeout in cluster-opt
+	run swarm manage --cluster-driver mesos-experimental --cluster-opt mesos.offertimeout=123asd 127.0.0.1:$MESOS_MASTER_PORT
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"Failed to parse mesos.offertimeout in Duration"* ]]
+
+	run swarm manage --cluster-driver mesos-experimental --cluster-opt mesos.offertimeout=-1 127.0.0.1:$MESOS_MASTER_PORT
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"mesos.offerTimeout cannot be a negative number"* ]]
+
+	# mesos.offerrefusetimeout in cluster-opt
+	run swarm manage --cluster-driver mesos-experimental --cluster-opt mesos.offerrefusetimeout=123asd 127.0.0.1:$MESOS_MASTER_PORT
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"Failed to parse mesos.offerrefusetimeout in Duration"* ]]
+
+	run swarm manage --cluster-driver mesos-experimental --cluster-opt mesos.offerrefusetimeout=-1 127.0.0.1:$MESOS_MASTER_PORT
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"mesos.offerrefusetimeout cannot be a negative number"* ]]
+}


### PR DESCRIPTION
1.change options validation in cluster/options.go
2.modify unit test of cluster options in cluster/options_test.go
3.validate cluster-opt in `swarm manage` in both mesos and swarm driver
4.add integration test of cluster-opts

This pr fixes #2018 

Signed-off-by: Sun Hongliang allen.sun@daocloud.io
