### PR TITLE
[WIP] return detailed error when two containers have same name

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -57,13 +57,17 @@ func sendErrorJSONMessage(w io.Writer, errorCode int, errorMessage string) {
 
 func getContainerFromVars(c *context, vars map[string]string) (string, *cluster.Container, error) {
 	if name, ok := vars["name"]; ok {
-		if container := c.cluster.Container(name); container != nil {
-			if !container.Engine.IsHealthy() {
-				return name, container, fmt.Errorf("Container %s running on unhealthy node %s", name, container.Engine.Name)
-			}
-			return name, container, nil
+		container, err := c.cluster.Container(name)
+		if err != nil {
+			// fail to get a container
+			return name, nil, err
 		}
-		return name, nil, fmt.Errorf("No such container: %s", name)
+
+		// get a container successfully
+		if !container.Engine.IsHealthy() {
+			return name, container, fmt.Errorf("Container %s running on unhealthy node %s", name, container.Engine.Name)
+		}
+		return name, container, nil
 	}
 
 	if ID, ok := vars["execid"]; ok {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -33,7 +33,7 @@ type Cluster interface {
 	// Return container the matching `IDOrName`
 	// TODO: remove this method from the interface as we can use
 	// cluster.Containers().Get(IDOrName)
-	Container(IDOrName string) *Container
+	Container(IDOrName string) (*Container, error)
 
 	// Return all networks
 	Networks() Networks

--- a/cluster/container_test.go
+++ b/cluster/container_test.go
@@ -32,29 +32,96 @@ func TestContainersGet(t *testing.T) {
 				"com.docker.swarm.id": "swarm2-id",
 			},
 		}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}),
+	}, {
+		Container: types.Container{
+			ID:    "container3-id",
+			Names: []string{"/container-dup"},
+		},
+		Engine: &Engine{ID: "test-engine"},
+		Config: BuildContainerConfig(containertypes.Config{
+			Labels: map[string]string{
+				"com.docker.swarm.id": "swarm3-id",
+			},
+		}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}),
+	}, {
+		Container: types.Container{
+			ID:    "container4-id",
+			Names: []string{"/container-dup"},
+		},
+		Engine: &Engine{ID: "test-engine"},
+		Config: BuildContainerConfig(containertypes.Config{
+			Labels: map[string]string{
+				"com.docker.swarm.id": "swarm4-id",
+			},
+		}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}),
 	}})
 
 	// Invalid lookup
-	assert.Nil(t, containers.Get("invalid-id"))
-	assert.Nil(t, containers.Get(""))
+	container, err := containers.Get("invalid-id")
+	assert.Nil(t, container)
+	assert.NotNil(t, err)
+
+	container, err = containers.Get("")
+	assert.Nil(t, container)
+	assert.NotNil(t, err)
+
 	// Container ID lookup.
-	assert.NotNil(t, containers.Get("container1-id"))
+	container, err = containers.Get("container1-id")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
 	// Container ID prefix lookup.
-	assert.NotNil(t, containers.Get("container1-"))
-	assert.Nil(t, containers.Get("container"))
+	container, err = containers.Get("container1-")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
+	container, err = containers.Get("container")
+	assert.Nil(t, container)
+	assert.NotNil(t, err)
+
 	// Container name lookup.
-	assert.NotNil(t, containers.Get("container1-name1"))
-	assert.NotNil(t, containers.Get("container1-name2"))
+	container, err = containers.Get("container1-name1")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
+	container, err = containers.Get("container1-name2")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
 	// Container engine/name matching.
-	assert.NotNil(t, containers.Get("test-engine/container1-name1"))
-	assert.NotNil(t, containers.Get("test-engine/container1-name2"))
+	container, err = containers.Get("test-engine/container1-name1")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
+	container, err = containers.Get("test-engine/container1-name2")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
 	// Swarm ID lookup.
-	assert.NotNil(t, containers.Get("swarm1-id"))
+	container, err = containers.Get("swarm1-id")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
 	// Swarm ID prefix lookup.
-	assert.NotNil(t, containers.Get("swarm1-"))
-	assert.Nil(t, containers.Get("swarm"))
+	container, err = containers.Get("swarm1-")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
+	container, err = containers.Get("swarm")
+	assert.Nil(t, container)
+	assert.NotNil(t, err)
+
+	// Same container name
+	container, err = containers.Get("container-dup")
+	assert.Nil(t, container)
+	assert.NotNil(t, err)
+
+	container, err = containers.Get("test-engine/container-dup")
+	assert.Nil(t, container)
+	assert.NotNil(t, err)
+
 	// Get name before ID prefix
-	cc := containers.Get("con")
-	assert.NotNil(t, cc)
-	assert.Equal(t, cc.ID, "container2-id")
+	container, err = containers.Get("con")
+	assert.NotNil(t, container)
+	assert.Equal(t, container.ID, "container2-id")
 }

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -346,17 +346,18 @@ func (c *Cluster) Containers() cluster.Containers {
 	return out
 }
 
-// Container returns the container with IdOrName in the cluster
-func (c *Cluster) Container(IDOrName string) *cluster.Container {
+// Container returns the container with IDOrName in the cluster
+func (c *Cluster) Container(IDOrName string) (*cluster.Container, error) {
 	// Abort immediately if the name is empty.
 	if len(IDOrName) == 0 {
-		return nil
+		return nil, fmt.Errorf("ID or name can not be empty")
 	}
 
 	c.RLock()
 	defer c.RUnlock()
 
-	return formatContainer(cluster.Containers(c.Containers()).Get(IDOrName))
+	container, err := cluster.Containers(c.Containers()).Get(IDOrName)
+	return formatContainer(container), err
 }
 
 // RemoveImage removes an image from the cluster

--- a/cluster/mesos/cluster_test.go
+++ b/cluster/mesos/cluster_test.go
@@ -75,21 +75,49 @@ func TestContainerLookup(t *testing.T) {
 	assert.Equal(t, len(c.Containers()), 2)
 
 	// Invalid lookup
-	assert.Nil(t, c.Container("invalid-id"))
-	assert.Nil(t, c.Container(""))
+	container, err := c.Container("invalid-id")
+	assert.Nil(t, container)
+	assert.NotNil(t, err)
+
+	container, err = c.Container("")
+	assert.Nil(t, container)
+	assert.NotNil(t, err)
+
 	// Container ID lookup.
-	assert.NotNil(t, c.Container("container1-id"))
+	container, err = c.Container("container1-id")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
 	// Container ID prefix lookup.
-	assert.NotNil(t, c.Container("container1-"))
-	assert.Nil(t, c.Container("container"))
+	container, err = c.Container("container1-")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
+	container, err = c.Container("container")
+	assert.Nil(t, container)
+	assert.NotNil(t, err)
+
 	// Container name lookup.
-	assert.NotNil(t, c.Container("container1-name1"))
-	assert.NotNil(t, c.Container("container1-name2"))
+	container, err = c.Container("container1-name1")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
+	container, err = c.Container("container1-name2")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
 	// Container engine/name matching.
-	assert.NotNil(t, c.Container("test-engine/container1-name1"))
-	assert.NotNil(t, c.Container("test-engine/container1-name2"))
-	// Match name before ID prefix
-	cc := c.Container("con")
-	assert.NotNil(t, cc)
-	assert.Equal(t, cc.ID, "container2-id")
+	container, err = c.Container("test-engine/container1-name1")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
+	container, err = c.Container("test-engine/container1-name2")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
+	// Get name before ID prefix
+	container, err = c.Container("con")
+	assert.NotNil(t, container)
+	assert.Equal(t, container.ID, "container2-id")
+
 }

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -131,7 +131,9 @@ func (c *Cluster) UnregisterEventHandler(h cluster.EventHandler) {
 func (c *Cluster) generateUniqueID() string {
 	for {
 		id := stringid.GenerateRandomID()
-		if c.Container(id) == nil {
+		if _, err := c.Container(id); err != nil {
+			continue
+		} else {
 			return id
 		}
 	}
@@ -755,10 +757,10 @@ func (c *Cluster) checkNameUniqueness(name string) bool {
 }
 
 // Container returns the container with IDOrName in the cluster
-func (c *Cluster) Container(IDOrName string) *cluster.Container {
+func (c *Cluster) Container(IDOrName string) (*cluster.Container, error) {
 	// Abort immediately if the name is empty.
 	if len(IDOrName) == 0 {
-		return nil
+		return nil, fmt.Errorf("ID or name can not be empty")
 	}
 
 	c.RLock()

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -98,28 +98,64 @@ func TestContainerLookup(t *testing.T) {
 	assert.Equal(t, len(c.Containers()), 2)
 
 	// Invalid lookup
-	assert.Nil(t, c.Container("invalid-id"))
-	assert.Nil(t, c.Container(""))
+	container, err := c.Container("invalid-id")
+	assert.Nil(t, container)
+	assert.NotNil(t, err)
+
+	container, err = c.Container("")
+	assert.Nil(t, container)
+	assert.NotNil(t, err)
+
 	// Container ID lookup.
-	assert.NotNil(t, c.Container("container1-id"))
+	container, err = c.Container("container1-id")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
 	// Container ID prefix lookup.
-	assert.NotNil(t, c.Container("container1-"))
-	assert.Nil(t, c.Container("container"))
+	container, err = c.Container("container1-")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
+	container, err = c.Container("container")
+	assert.Nil(t, container)
+	assert.NotNil(t, err)
+
 	// Container name lookup.
-	assert.NotNil(t, c.Container("container1-name1"))
-	assert.NotNil(t, c.Container("container1-name2"))
+	container, err = c.Container("container1-name1")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
+	container, err = c.Container("container1-name2")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
 	// Container engine/name matching.
-	assert.NotNil(t, c.Container("test-engine/container1-name1"))
-	assert.NotNil(t, c.Container("test-engine/container1-name2"))
+	container, err = c.Container("test-engine/container1-name1")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
+	container, err = c.Container("test-engine/container1-name2")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
 	// Swarm ID lookup.
-	assert.NotNil(t, c.Container("swarm1-id"))
+	container, err = c.Container("swarm1-id")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
 	// Swarm ID prefix lookup.
-	assert.NotNil(t, c.Container("swarm1-"))
-	assert.Nil(t, c.Container("swarm"))
-	// Match name before ID prefix
-	cc := c.Container("con")
-	assert.NotNil(t, cc)
-	assert.Equal(t, cc.ID, "container2-id")
+	container, err = c.Container("swarm1-")
+	assert.NotNil(t, container)
+	assert.Nil(t, err)
+
+	container, err = c.Container("swarm")
+	assert.Nil(t, container)
+	assert.NotNil(t, err)
+
+	// Get name before ID prefix
+	container, err = c.Container("con")
+	assert.NotNil(t, container)
+	assert.Equal(t, container.ID, "container2-id")
 }
 
 func TestImportImage(t *testing.T) {

--- a/scheduler/node/node.go
+++ b/scheduler/node/node.go
@@ -49,7 +49,8 @@ func (n *Node) IsHealthy() bool {
 
 // Container returns the container with IDOrName in the engine.
 func (n *Node) Container(IDOrName string) *cluster.Container {
-	return n.Containers.Get(IDOrName)
+	container, _ := n.Containers.Get(IDOrName)
+	return container
 }
 
 // AddContainer injects a container into the internal state.


### PR DESCRIPTION
fix #2064 
1. return detailed error getting container by name when two containers have same name;
   changes are in /cluster/container.go
2. add unit tests;
   changes are in /cluster/container_test.go
3. change api/handlers.go

Integration tests will be added as soon.

Signed-off-by: Sun Hongliang allen.sun@daocloud.io
