### PR TITLE
fix the bug that connection cannot be closed when the client close request to /containers/{stopped container id}/stats

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -122,8 +122,8 @@ func proxyAsync(engine *cluster.Engine, w http.ResponseWriter, r *http.Request, 
 			CancelRequest(*http.Request)
 		}
 
-		if closeNotifier, ok = w.(http.CloseNotifier); ok == false {
-			log.Error("ResponseWriter was not support CloseNotify")
+		if closeNotifier, ok = w.(http.CloseNotifier); !ok {
+			log.Error("ResponseWriter does not support CloseNotify")
 			return
 		}
 
@@ -131,8 +131,8 @@ func proxyAsync(engine *cluster.Engine, w http.ResponseWriter, r *http.Request, 
 		case <-closeNotifier.CloseNotify():
 			{
 				var cancel canceler
-				if cancel, ok = client.Transport.(canceler); ok == false {
-					log.Error("client.Transport was not support CancelRequest")
+				if cancel, ok = client.Transport.(canceler); !ok {
+					log.Error("client.Transport does not support CancelRequest")
 					return
 				}
 

--- a/api/utils.go
+++ b/api/utils.go
@@ -103,17 +103,66 @@ func proxyAsync(engine *cluster.Engine, w http.ResponseWriter, r *http.Request, 
 	r.URL.Host = engine.Addr
 
 	log.WithFields(log.Fields{"method": r.Method, "url": r.URL}).Debug("Proxy request")
+
+	var (
+		writeCompleted  = make(chan bool)
+		dectedCompleted = make(chan bool)
+	)
+
+    //if docker server did not write any data in body ( just like request /containers/xxx/stats to stopped container) , `io.Copy(NewWriteFlusher(w), resp.Body)` will wait for reading data.
+    //But the client that connect to swarm may close the request . So we should dected it and  cancel the request to docker server.
+	go func() {
+
+		var (
+			closeNotifier http.CloseNotifier
+			ok            bool
+		)
+
+		type canceler interface {
+			CancelRequest(*http.Request)
+		}
+
+		if closeNotifier, ok = w.(http.CloseNotifier); ok == false {
+			log.Error("ResponseWriter was not support CloseNotify")
+			return
+		}
+
+		select {
+		case <-closeNotifier.CloseNotify():
+			{
+                var cancel canceler
+				if cancel, ok = client.Transport.(canceler); ok == false {
+					log.Error("client.Transport was not support CancelRequest")
+					return
+				}
+
+				cancel.CancelRequest(r)
+				dectedCompleted <- true
+			}
+		case <-writeCompleted:
+			break
+		}
+
+	}()
+
 	resp, err := client.Do(r)
 	if err != nil {
 		return err
 	}
 
 	copyHeader(w.Header(), resp.Header)
-	w.WriteHeader(resp.StatusCode)
+	w.WriteHeader(resp.StatusCode) 
 	io.Copy(NewWriteFlusher(w), resp.Body)
 
 	if callback != nil {
 		callback(resp)
+	}
+
+	select {
+	case <-dectedCompleted://goroutine already return , there is no need to send `writeCompleted``
+		break
+	case writeCompleted <- true://tell goroutine to return if every thing is normal
+		break
 	}
 
 	// cleanup


### PR DESCRIPTION
`Bug description`:
when client connect to swarm ,and request to `/containers/{ id of stopped container }/stats` api .the docker server didn't write any data in body to swarm. But when we close the request of client, the connection of swarm and docker server was not be closed.

I have try to fix the bug .

`Reproduce`:
As I say ,you can reproduce the bug : 
1. Join your docker host into swarm
2. Run a container and stop it  on your host (Don't forget to stop it !)
3. Using your browser, and request to  http://swarm-address/containers/{container you just stopped}/stats . and wait for a seconds and stop it .  
4. Do `step 3` for many times and exec `sudo lsof -i:2375` ,  you will see the connection created again and again.  

Signed-off-by:  chengjt chengjt@csdn.net
