### PR TITLE
add expvar into Swarm to show public variables and fix a pprof URL

### DIFF
--- a/api/primary.go
+++ b/api/primary.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"crypto/tls"
+	"expvar"
+	"fmt"
 	"net/http"
 
 	"net/http/pprof"
@@ -103,15 +105,31 @@ func writeCorsHeaders(w http.ResponseWriter, r *http.Request) {
 
 func profilerSetup(mainRouter *mux.Router, path string) {
 	var r = mainRouter.PathPrefix(path).Subrouter()
+	r.HandleFunc("/vars", expVars)
 	r.HandleFunc("/pprof/", pprof.Index)
 	r.HandleFunc("/pprof/cmdline", pprof.Cmdline)
 	r.HandleFunc("/pprof/profile", pprof.Profile)
 	r.HandleFunc("/pprof/symbol", pprof.Symbol)
-	r.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	r.HandleFunc("/pprof/trace", pprof.Trace)
 	r.HandleFunc("/pprof/block", pprof.Handler("block").ServeHTTP)
 	r.HandleFunc("/pprof/heap", pprof.Handler("heap").ServeHTTP)
 	r.HandleFunc("/pprof/goroutine", pprof.Handler("goroutine").ServeHTTP)
 	r.HandleFunc("/pprof/threadcreate", pprof.Handler("threadcreate").ServeHTTP)
+}
+
+// Replicated from expvar.go as not public.
+func expVars(w http.ResponseWriter, r *http.Request) {
+	first := true
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	fmt.Fprintf(w, "{\n")
+	expvar.Do(func(kv expvar.KeyValue) {
+		if !first {
+			fmt.Fprintf(w, ",\n")
+		}
+		first = false
+		fmt.Fprintf(w, "%q: %s", kv.Key, kv.Value)
+	})
+	fmt.Fprintf(w, "\n}\n")
 }
 
 // NewPrimary creates a new API router.


### PR DESCRIPTION
I found that docker daemon uses package expvar to show process environment details of itself.
We can see it here https://github.com/docker/docker/blob/v1.11.1/api/server/profiler.go#L16

This PR did:
1. add expvar in Swarm, the added function `expVars` is from https://github.com/docker/docker/blob/v1.11.1/api/server/profiler.go#L28-L40;
2. change a pprof URL in trace

I added expvar in Swarm, After that we can get the details of process using `http://127.0.0.1:2375/debug/vars` like below:

```
{
"cmdline": ["/root/gocode/bin/swarm","-debug","manage","-H","tcp://0.0.0.0:2375","nodes://10.1.0.108:2376"],
"memstats": {
"Alloc":4894936,
"TotalAlloc":8457192,
"Sys":10688760,
"Lookups":15,
"Mallocs":48187,
"Frees":40021,
"HeapAlloc":4894936,
"HeapSys":7929856,
"HeapIdle":1015808,
"HeapInuse":6914048,
"HeapReleased":0,
"HeapObjects":8166,
"StackInuse":458752,
"StackSys":458752,
"MSpanInuse":62944,
"MSpanSys":65536,
"MCacheInuse":1208,
"MCacheSys":16384,
"BuckHashSys":1446848,
"GCSys":270080,
"OtherSys":501304,
"NextGC":8057917,
"LastGC":1463123130572449932,
"PauseTotalNs":251650,
"PauseNs":[132949,118701,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
"PauseEnd":[1463123120448474072,1463123130572449932,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
"NumGC":2,
"GCCPUFraction":0.00029956328850212733,
"EnableGC":true,
"DebugGC":false,
"BySize":[{"Size":0,"Mallocs":0,"Frees":0},{"Size":8,"Mallocs":657,"Frees":446},{"Size":16,"Mallocs":23236,"Frees":20969},{"Size":32,"Mallocs":4811,"Frees":3557},{"Size":48,"Mallocs":3047,"Frees":1866},{"Size":64,"Mallocs":1916,"Frees":1356},{"Size":80,"Mallocs":684,"Frees":543},{"Size":96,"Mallocs":698,"Frees":505},{"Size":112,"Mallocs":8006,"Frees":7357},{"Size":128,"Mallocs":490,"Frees":408},{"Size":144,"Mallocs":226,"Frees":175},{"Size":160,"Mallocs":910,"Frees":577},{"Size":176,"Mallocs":193,"Frees":133},{"Size":192,"Mallocs":10,"Frees":4},{"Size":208,"Mallocs":118,"Frees":69},{"Size":224,"Mallocs":145,"Frees":139},{"Size":240,"Mallocs":24,"Frees":16},{"Size":256,"Mallocs":302,"Frees":290},{"Size":288,"Mallocs":337,"Frees":178},{"Size":320,"Mallocs":383,"Frees":276},{"Size":352,"Mallocs":59,"Frees":29},{"Size":384,"Mallocs":53,"Frees":7},{"Size":416,"Mallocs":82,"Frees":38},{"Size":448,"Mallocs":103,"Frees":67},{"Size":480,"Mallocs":38,"Frees":14},{"Size":512,"Mallocs":295,"Frees":214},{"Size":576,"Mallocs":61,"Frees":17},{"Size":640,"Mallocs":310,"Frees":209},{"Size":704,"Mallocs":36,"Frees":30},{"Size":768,"Mallocs":5,"Frees":5},{"Size":896,"Mallocs":55,"Frees":43},{"Size":1024,"Mallocs":205,"Frees":185},{"Size":1152,"Mallocs":18,"Frees":8},{"Size":1280,"Mallocs":167,"Frees":74},{"Size":1408,"Mallocs":5,"Frees":2},{"Size":1536,"Mallocs":10,"Frees":10},{"Size":1664,"Mallocs":19,"Frees":7},{"Size":2048,"Mallocs":124,"Frees":100},{"Size":2304,"Mallocs":5,"Frees":1},{"Size":2560,"Mallocs":53,"Frees":22},{"Size":2816,"Mallocs":1,"Frees":1},{"Size":3072,"Mallocs":0,"Frees":0},{"Size":3328,"Mallocs":10,"Frees":4},{"Size":4096,"Mallocs":42,"Frees":34},{"Size":4608,"Mallocs":0,"Frees":0},{"Size":5376,"Mallocs":17,"Frees":12},{"Size":6144,"Mallocs":98,"Frees":2},{"Size":6400,"Mallocs":1,"Frees":1},{"Size":6656,"Mallocs":3,"Frees":0},{"Size":6912,"Mallocs":0,"Frees":0},{"Size":8192,"Mallocs":3,"Frees":3},{"Size":8448,"Mallocs":0,"Frees":0},{"Size":8704,"Mallocs":1,"Frees":1},{"Size":9472,"Mallocs":0,"Frees":0},{"Size":10496,"Mallocs":0,"Frees":0},{"Size":12288,"Mallocs":12,"Frees":10},{"Size":13568,"Mallocs":0,"Frees":0},{"Size":14080,"Mallocs":0,"Frees":0},{"Size":16384,"Mallocs":2,"Frees":2},{"Size":16640,"Mallocs":0,"Frees":0},{"Size":17664,"Mallocs":0,"Frees":0}]}
}
```

Signed-off-by: Sun Hongliang allen.sun@daocloud.io
