### PR TITLE
[WIP]Set desired state for rescheduled container

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -30,6 +30,9 @@ type Cluster interface {
 	// Start a container
 	StartContainer(container *Container, hostConfig *dockerclient.HostConfig) error
 
+	// Pause a conatiner
+	PauseContainer(container *Container) error
+
 	// Return container the matching `IDOrName`
 	// TODO: remove this method from the interface as we can use
 	// cluster.Containers().Get(IDOrName)

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -913,6 +913,18 @@ func (e *Engine) Create(config *ContainerConfig, name string, pullImage bool, au
 	return container, err
 }
 
+// PauseContainer pauses a container from the engine.
+func (e *Engine) PauseContainer(ID string) error {
+	err := e.apiClient.ContainerPause(context.Background(), ID)
+	e.CheckConnectionErr(err)
+	if err != nil {
+		return err
+	}
+
+	e.refreshContainer(ID, true)
+	return nil
+}
+
 // RemoveContainer removes a container from the engine.
 func (e *Engine) RemoveContainer(container *Container, force, volumes bool) error {
 	opts := types.ContainerRemoveOptions{

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -190,6 +190,11 @@ func (c *Cluster) StartContainer(container *cluster.Container, hostConfig *docke
 	return nil
 }
 
+// PauseContainer pauses a container
+func (c *Cluster) PauseContainer(container *cluster.Container) error {
+	return container.Engine.PauseContainer(container.ID)
+}
+
 // CreateContainer for container creation in Mesos task
 func (c *Cluster) CreateContainer(config *cluster.ContainerConfig, name string, authConfig *types.AuthConfig) (*cluster.Container, error) {
 	if config.HostConfig.Memory == 0 && config.HostConfig.CPUShares == 0 {

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -142,6 +142,11 @@ func (c *Cluster) StartContainer(container *cluster.Container, hostConfig *docke
 	return container.Engine.StartContainer(container.ID, hostConfig)
 }
 
+// PauseContainer pauses a container
+func (c *Cluster) PauseContainer(container *cluster.Container) error {
+	return container.Engine.PauseContainer(container.ID)
+}
+
 // CreateContainer aka schedule a brand new container into the cluster.
 func (c *Cluster) CreateContainer(config *cluster.ContainerConfig, name string, authConfig *types.AuthConfig) (*cluster.Container, error) {
 	container, err := c.createContainer(config, name, false, authConfig)


### PR DESCRIPTION
Fixed #1891 

Currently in container rescheduling, Swarm will start all rescheduled container to **Running** state.
While In reality, before rescheduling, container can have several kinds of state: **paused, starting, dead, exited as well**.
 And I think Swarm should take this fact into consideration and set the desired state.

This PR did:
1. Add `PauseContainer` in interface `type Cluster interface`;
2. Add set desired state in the logic `rescheduleContainers`;
3. Implement `PauseContainer` both in swarm/cluster and mesos/cluster;
4. Implement `PauseContainer` in engine.go.

Signed-off-by: allencloud allen.sun@daocloud.io
