### PR TITLE
[WIP]make container state and status sync in API '/containers/json'

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -449,8 +449,9 @@ func getContainersJSON(c *context, w http.ResponseWriter, r *http.Request) {
 		// make changes without messing with cluster.Container.
 		tmp := (*container).Container
 
-		// Update the Status. The one we have is stale from the last `docker ps` the engine sent.
+		// Update the State and Status. The one we have is stale from the last `docker ps` the engine sent.
 		// `Status()` will generate a new one
+		tmp.State = cluster.StateString(container.Info.State)
 		tmp.Status = cluster.FullStateString(container.Info.State)
 		if !container.Engine.IsHealthy() {
 			tmp.Status = "Host Down"


### PR DESCRIPTION
Fixed #2264 , this is a severe **BUG** which cause **inconsistency**.

When `docker ps` against Swarm, Swarm handles container state using code

```
tmp.Status = cluster.FullStateString(container.Info.State)
if !container.Engine.IsHealthy() {
    tmp.Status = "Host Down"
}
```

So if `Container` and `Info` in `type Container struct` are not synchronized with each other, `docker ps` response will show inconsistency. Issue #2264 showed what will happen.

```
type Container struct {
    types.Container

    Config *ContainerConfig
    Info   types.ContainerJSON
    Engine *Engine
}
```

This PR did:
1.When swarm handling `/containers/json` API, it forces to use `Info   types.ContainerJSON` to construct `state` and `status` in `types.Container`.

Signed-off-by: allencloud allen.sun@daocloud.io
