### PR TITLE
Add constraint filter field to /images/create

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -318,5 +318,9 @@ func int64ValueOrZero(r *http.Request, k string) int64 {
 }
 
 func tagHasDigest(tag string) bool {
-	return strings.Contains(tag, ":")
+	return !strings.Contains(tag, "constraint:") && strings.Contains(tag, ":")
+}
+
+func tagHasConstraints(tag string) bool {
+	return strings.Contains(tag, "constraint:")
 }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -22,7 +22,7 @@ type Cluster interface {
 	Image(IDOrName string) *Image
 
 	// Remove images from the cluster
-	RemoveImages(name string, force bool) ([]types.ImageDelete, error)
+	RemoveImages(name string, constraints []string, force bool) ([]types.ImageDelete, error)
 
 	// Return all containers
 	Containers() Containers
@@ -57,7 +57,7 @@ type Cluster interface {
 	// `callback` can be called multiple time
 	//  `where` is where it is being pulled
 	//  `status` is the current status, like "", "in progress" or "downloaded
-	Pull(name string, authConfig *types.AuthConfig, callback func(where, status string, err error))
+	Pull(name string, constraints []string, authConfig *types.AuthConfig, callback func(where, status string, err error))
 
 	// Import image
 	// `callback` can be called multiple time

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -251,7 +251,7 @@ func (c *Cluster) Image(IDOrName string) *cluster.Image {
 }
 
 // RemoveImages removes images from the cluster
-func (c *Cluster) RemoveImages(name string, force bool) ([]types.ImageDelete, error) {
+func (c *Cluster) RemoveImages(name string, constraints []string, force bool) ([]types.ImageDelete, error) {
 	return nil, errNotSupported
 }
 
@@ -365,7 +365,7 @@ func (c *Cluster) RemoveImage(image *cluster.Image) ([]types.ImageDelete, error)
 }
 
 // Pull pulls images on the cluster nodes
-func (c *Cluster) Pull(name string, authConfig *types.AuthConfig, callback func(where, status string, err error)) {
+func (c *Cluster) Pull(name string, constraints []string, authConfig *types.AuthConfig, callback func(where, status string, err error)) {
 
 }
 

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -434,7 +434,7 @@ func (c *Cluster) Image(IDOrName string) *cluster.Image {
 
 // RemoveImages removes all the images that match `name` from the cluster
 func (c *Cluster) RemoveImages(name string, constraints []string, force bool) ([]types.ImageDelete, error) {
-	nodes, err := filter.FilterWithConstraints(constraints, c.listNodes(), false)
+	nodes, err := filter.WithConstraints(constraints, c.listNodes(), false)
 
 	if err != nil {
 		return nil, err
@@ -585,7 +585,7 @@ func (c *Cluster) RemoveVolumes(name string) (bool, error) {
 func (c *Cluster) Pull(name string, constraints []string, authConfig *types.AuthConfig, callback func(where, status string, err error)) {
 	var wg sync.WaitGroup
 
-	nodes, err := filter.FilterWithConstraints(constraints, c.listNodes(), false)
+	nodes, err := filter.WithConstraints(constraints, c.listNodes(), false)
 
 	if err != nil {
 		callback("swarm", "invalid constraint(s)", err)

--- a/docs/swarm-api.md
+++ b/docs/swarm-api.md
@@ -80,24 +80,6 @@ POST "/images/create" : "docker import" flow not implement
             Containers started from the <code>swarm</code> official image are hidden by default, use <code>all=1</code> to display them.
         </td>
     </tr>
-    </tr>
-        <tr>
-        <td>
-            <code>GET "/images/create"</code>
-        </td>
-        <td>
-            Optional extra field: <code>constraints</code>, used to limit where the image is pulled. Can be specified multiple times for multiple constraints.
-        </td>
-    </tr>
-    </tr>
-        <tr>
-        <td>
-            <code>DELETE "/images/{name:.*}"</code>
-        </td>
-        <td>
-            Optional extra field: <code>constraints</code>, used to limit where the image is pulled. Can be specified multiple times for multiple constraints.
-        </td>
-    </tr>
     <tr>
         <td>
             <code>GET "/images/json"</code>

--- a/docs/swarm-api.md
+++ b/docs/swarm-api.md
@@ -80,6 +80,24 @@ POST "/images/create" : "docker import" flow not implement
             Containers started from the <code>swarm</code> official image are hidden by default, use <code>all=1</code> to display them.
         </td>
     </tr>
+    </tr>
+        <tr>
+        <td>
+            <code>GET "/images/create"</code>
+        </td>
+        <td>
+            Optional extra field: <code>constraints</code>, used to limit where the image is pulled. Can be specified multiple times for multiple constraints.
+        </td>
+    </tr>
+    </tr>
+        <tr>
+        <td>
+            <code>DELETE "/images/{name:.*}"</code>
+        </td>
+        <td>
+            Optional extra field: <code>constraints</code>, used to limit where the image is pulled. Can be specified multiple times for multiple constraints.
+        </td>
+    </tr>
     <tr>
         <td>
             <code>GET "/images/json"</code>

--- a/scheduler/filter/constraint.go
+++ b/scheduler/filter/constraint.go
@@ -19,7 +19,11 @@ func (f *ConstraintFilter) Name() string {
 
 // Filter is exported
 func (f *ConstraintFilter) Filter(config *cluster.ContainerConfig, nodes []*node.Node, soft bool) ([]*node.Node, error) {
-	constraints, err := parseExprs(config.Constraints())
+	return FilterWithConstraints(config.Constraints(), nodes, soft)
+}
+
+func FilterWithConstraints(constraintList []string, nodes []*node.Node, soft bool) ([]*node.Node, error) {
+	constraints, err := parseExprs(constraintList)
 	if err != nil {
 		return nil, err
 	}

--- a/scheduler/filter/constraint.go
+++ b/scheduler/filter/constraint.go
@@ -19,10 +19,11 @@ func (f *ConstraintFilter) Name() string {
 
 // Filter is exported
 func (f *ConstraintFilter) Filter(config *cluster.ContainerConfig, nodes []*node.Node, soft bool) ([]*node.Node, error) {
-	return FilterWithConstraints(config.Constraints(), nodes, soft)
+	return WithConstraints(config.Constraints(), nodes, soft)
 }
 
-func FilterWithConstraints(constraintList []string, nodes []*node.Node, soft bool) ([]*node.Node, error) {
+// WithConstraints returns a list of nodes that meet the specified constraints
+func WithConstraints(constraintList []string, nodes []*node.Node, soft bool) ([]*node.Node, error) {
 	constraints, err := parseExprs(constraintList)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds the ability to pass a comma separated list of constraints in order to specify which hosts should pull or delete the image.

I'm not sure what the convention is around adding features like this that are only applicable to swarm and not docker engine itself, so I wrote it in the simplest way possible for now. If there's a different way this should be done, please comment.

Addresses #1692.
