### PR TITLE
Optimizing matching of image affinity

### DIFF
--- a/scheduler/filter/affinity.go
+++ b/scheduler/filter/affinity.go
@@ -45,18 +45,18 @@ func (f *AffinityFilter) Filter(config *cluster.ContainerConfig, nodes []*node.N
 					candidates = append(candidates, node)
 				}
 			case "image":
-				images := []string{}
+				images := make(map[string]int)
 				for _, image := range node.Images {
-					images = append(images, image.ID)
-					images = append(images, image.RepoTags...)
+					images_map[image.ID] = 1
 					for _, tag := range image.RepoTags {
 						repo, _ := cluster.ParseRepositoryTag(tag)
-						images = append(images, repo)
+						images[repo] = 1
 					}
 				}
-				if affinity.Match(images...) {
+				if _, ok := images[affinity.value]; ok {
 					candidates = append(candidates, node)
 				}
+
 			default:
 				labels := []string{}
 				for _, container := range node.Containers {

--- a/scheduler/filter/affinity.go
+++ b/scheduler/filter/affinity.go
@@ -47,9 +47,10 @@ func (f *AffinityFilter) Filter(config *cluster.ContainerConfig, nodes []*node.N
 			case "image":
 				images := make(map[string]int)
 				for _, image := range node.Images {
-					images_map[image.ID] = 1
+					images[image.ID] = 1
 					for _, tag := range image.RepoTags {
 						repo, _ := cluster.ParseRepositoryTag(tag)
+						images[tag] = 1
 						images[repo] = 1
 					}
 				}


### PR DESCRIPTION
The affinity.Match(images...) iterates all over a images slice with the ID and tags of all images for each node in the swarm cluster. With a large number of images  the execution time of this function increases affecting the performance when creating a new container. In our case, with thousands of images for each node, this function takes 4-5 seconds to return.

Our proposal changes the images slice with a map with the image ID or tag as a key and 1 as a value. If images[affinity.value] exists, the node is added to the candidates slice. After this change, currently run in production the time to select a node to create the container with affinity reduces from 10 seconds (2 nodes, 10000 images) to milliseconds.
