### PR TITLE
Add curl to the base swarm image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex \
 	git \
 	&& GOOS=$GOOS CGO_ENABLED=0 go install -v -a -tags netgo -installsuffix netgo -ldflags "-w -X github.com/docker/swarm/version.GITCOMMIT `git rev-parse --short HEAD` -X github.com/docker/swarm/version.BUILDTIME \"`date -u`\""  \
 	&& apk del .build-deps
+	&& apk update && apk add curl
 
 ENV SWARM_HOST :2375
 EXPOSE 2375

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps \
 	git \
 	&& GOOS=$GOOS CGO_ENABLED=0 go install -v -a -tags netgo -installsuffix netgo -ldflags "-w -X github.com/docker/swarm/version.GITCOMMIT `git rev-parse --short HEAD` -X github.com/docker/swarm/version.BUILDTIME \"`date -u`\""  \
-	&& apk del .build-deps
+	&& apk del .build-deps \
 	&& apk update && apk add curl
 
 ENV SWARM_HOST :2375


### PR DESCRIPTION
 Allows running swarm commands using curl from within the container. Makes for a very useful way to test the service status. Adds 2MB to the final image.

Very useful when running Health Checks from Marathon using mesos.

Signed-off-by: Guillermo Rodriguez grodriguez@cmcrc.com
