### PR TITLE
Centralised engine state changes to the same method

### DIFF
--- a/cluster/engine_test.go
+++ b/cluster/engine_test.go
@@ -67,9 +67,9 @@ func (nopCloser) Close() error {
 func TestSetEngineState(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
 	assert.True(t, engine.state == statePending)
-	engine.setState(stateUnhealthy)
+	engine.setState(stateUnhealthy, true)
 	assert.True(t, engine.state == stateUnhealthy)
-	engine.setState(stateHealthy)
+	engine.setState(stateHealthy, true)
 	assert.True(t, engine.state == stateHealthy)
 }
 
@@ -83,7 +83,7 @@ func TestErrMsg(t *testing.T) {
 
 func TestCheckConnectionErr(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
-	engine.setState(stateHealthy)
+	engine.setState(stateHealthy, true)
 	assert.True(t, engine.failureCount == 0)
 	err := dockerclient.ErrConnectionRefused
 	engine.CheckConnectionErr(err)
@@ -107,7 +107,7 @@ func TestCheckConnectionErr(t *testing.T) {
 
 func TestEngineFailureCount(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
-	engine.setState(stateHealthy)
+	engine.setState(stateHealthy, true)
 	for i := 0; i < engine.opts.FailureRetry; i++ {
 		assert.True(t, engine.IsHealthy())
 		engine.incFailureCount()
@@ -122,9 +122,9 @@ func TestHealthIndicator(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
 	assert.True(t, engine.state == statePending)
 	assert.True(t, engine.HealthIndicator() == 0)
-	engine.setState(stateUnhealthy)
+	engine.setState(stateUnhealthy, true)
 	assert.True(t, engine.HealthIndicator() == 0)
-	engine.setState(stateHealthy)
+	engine.setState(stateHealthy, true)
 	assert.True(t, engine.HealthIndicator() == 100)
 	engine.incFailureCount()
 	assert.True(t, engine.HealthIndicator() == (int64)(100-100/engine.opts.FailureRetry))
@@ -171,7 +171,7 @@ func TestOutdatedEngine(t *testing.T) {
 
 func TestEngineCpusMemory(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
-	engine.setState(stateUnhealthy)
+	engine.setState(stateUnhealthy, true)
 	assert.False(t, engine.isConnected())
 
 	client := mockclient.NewMockClient()
@@ -201,7 +201,7 @@ func TestEngineCpusMemory(t *testing.T) {
 
 func TestEngineSpecs(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
-	engine.setState(stateUnhealthy)
+	engine.setState(stateUnhealthy, true)
 	assert.False(t, engine.isConnected())
 
 	client := mockclient.NewMockClient()
@@ -243,7 +243,7 @@ func TestEngineSpecs(t *testing.T) {
 
 func TestEngineState(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
-	engine.setState(stateUnhealthy)
+	engine.setState(stateUnhealthy, true)
 	assert.False(t, engine.isConnected())
 
 	client := mockclient.NewMockClient()
@@ -381,7 +381,7 @@ func TestCreateContainer(t *testing.T) {
 		readCloser = nopCloser{bytes.NewBufferString("")}
 	)
 
-	engine.setState(stateUnhealthy)
+	engine.setState(stateUnhealthy, true)
 	apiClient.On("Info", mock.Anything).Return(mockInfo, nil)
 	apiClient.On("ServerVersion", mock.Anything).Return(mockVersion, nil)
 	apiClient.On("NetworkList", mock.Anything,
@@ -549,7 +549,7 @@ func TestCreateContainer(t *testing.T) {
 
 func TestImages(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
-	engine.setState(stateHealthy)
+	engine.setState(stateHealthy, true)
 	engine.images = []*Image{
 		{types.Image{ID: "a"}, engine},
 		{types.Image{ID: "b"}, engine},
@@ -587,7 +587,7 @@ func TestUsedCpus(t *testing.T) {
 	)
 
 	engine := NewEngine("test", 0, engOpts)
-	engine.setState(stateHealthy)
+	engine.setState(stateHealthy, true)
 	client := mockclient.NewMockClient()
 	apiClient := engineapimock.NewMockClient()
 
@@ -674,7 +674,7 @@ func TestContainerRemovedDuringRefresh(t *testing.T) {
 	)
 
 	engine := NewEngine("test", 0, engOpts)
-	engine.setState(stateUnhealthy)
+	engine.setState(stateUnhealthy, true)
 	assert.False(t, engine.isConnected())
 
 	// A container is removed before it can be inspected.


### PR DESCRIPTION
I think we should use the same method to change engine's state. It will help us control the way to change engine's state, so as not to mess up engine's state.

Ping @allencloud  @dongluochen   @nishanttotla 

Signed-off-by: Xianlu xianlu.cxl@alibaba-inc.com
