### PR TITLE
Retain error message when create volume avoid being covered

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -547,9 +547,9 @@ func (c *Cluster) CreateVolume(request *types.VolumeCreateRequest) (*types.Volum
 				v, er := engine.CreateVolume(request)
 				if v != nil {
 					volume = v
-					err = nil
 				}
-				if er != nil && volume == nil {
+				if er != nil {
+					log.WithField("engineName", engine.Name).Errorf("Create volume error: %v", er)
 					err = er
 				}
 			}(e)
@@ -564,14 +564,7 @@ func (c *Cluster) CreateVolume(request *types.VolumeCreateRequest) (*types.Volum
 			return nil, err
 		}
 		if nodes != nil {
-			v, er := c.engines[nodes[0].ID].CreateVolume(request)
-			if v != nil {
-				volume = v
-				err = nil
-			}
-			if er != nil && volume == nil {
-				err = er
-			}
+			return c.engines[nodes[0].ID].CreateVolume(request)
 		}
 	}
 


### PR DESCRIPTION
When create volume on swarm, if a engine create volume error, its error message will be covered by next success engine. Some engine hasn't created volume succeed, but for cluster, this method return None error. So we should keep its error message whether any one engine create volume error, we all think cluster create volume error.

@allencloud @dongluochen @nishanttotla WDYT ?
