### PR TITLE
Use map to optimize Entries.Diff()

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -390,7 +390,7 @@ func (c *Cluster) monitorDiscovery(ch <-chan discovery.Entries, errCh <-chan err
 	for {
 		select {
 		case entries := <-ch:
-			added, removed, current := entries.Diff(lastEntryMap)
+			added, removed, current := entries.Diff(currentEntryMap)
 			currentEntryMap = current
 
 			// Remove engines first. `addEngine` will refuse to add an engine


### PR DESCRIPTION
The Entries.Diff() cost a lot of CPU resource when a lot of Docker nodes. So use map to optimize it, may be used more memory space, but time is shortened.