### PR TITLE
Ignore volume-from attribute for rescheduling containers on node fail

### DIFF
--- a/cluster/watchdog.go
+++ b/cluster/watchdog.go
@@ -134,6 +134,13 @@ func (w *Watchdog) rescheduleContainers(e *Engine) {
 			endpointsConfig[k] = v
 		}
 		c.Config.NetworkingConfig.EndpointsConfig = endpointsConfig
+		
+		//For volume-from case, ignore it
+		if c.Config.HostConfig.VolumesFrom != nil {
+			log.Warnf("Set container %s volume-from attribute to nil for rescheduling", c.Info.Name)
+			c.Config.HostConfig.VolumesFrom = nil
+		}
+
 		newContainer, err := w.cluster.CreateContainer(c.Config, c.Info.Name, nil)
 		if err != nil {
 			log.Errorf("Failed to reschedule container %s: %v", c.ID, err)


### PR DESCRIPTION
In some case, container has `volume-from` attribute. When reschedule this container on node fail, it can not to be created on other nodes. So we should ignore `volume-from` attribute when node failed reschedule.

@dongluochen @nishanttotla WDYT ? Maybe it can be merged in 1.2.6 millstone.

Signed-off-by: Xianlu <xianlu.cxl@alibaba-inc.com>