### PR TITLE
Retry container rescheduling

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -28,6 +28,7 @@ var (
 				flTLS, flTLSCaCert, flTLSCert, flTLSKey, flTLSVerify,
 				flRefreshIntervalMin, flRefreshIntervalMax, flFailureRetry, flRefreshRetry,
 				flHeartBeat,
+				flRescheduleRetry, flRescheduleRetryInterval,
 				flEnableCors,
 				flCluster, flDiscoveryOpt, flClusterOpt, flRefreshOnNodeFilter, flContainerNameRefreshFilter},
 			Action: manage,

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -152,6 +152,17 @@ var (
 		Usage: "Leader lock release time on failure",
 	}
 
+	flRescheduleRetry = cli.IntFlag{
+		Name:  "reschedule-retry",
+		Value: 1,
+		Usage: "The limit on the number of attempts to reschedule a container",
+	}
+	flRescheduleRetryInterval = cli.StringFlag{
+		Name:  "reschedule-retry-interval",
+		Value: "0s",
+		Usage: "The delay between container rescheduling attempts.",
+	}
+
 	flRefreshOnNodeFilter = cli.BoolFlag{
 		Name:  "refresh-on-node-filter",
 		Usage: "If true, refresh the cache when a ContainerList call comes in with a node filter",


### PR DESCRIPTION
Previously, the manager attempted to reschedule containers with a policy
of on-node-failure only once.  If this single rescheduling attempt failed,
the container would never be restarted unless the user took action.

Now, the manager will retry failed rescheduling attempts every 20 seconds,
up to a maximum of 5 minutes.

At the moment the rescheduling retry policy is hard-coded; it might be
nice to expose this policy to the user via a command line option.

Signed-off-by: Daniel Ferstay <dan@cohodata.com>