### PR TITLE
Remove OldContainerConfig struct

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -627,22 +627,10 @@ func postContainersCreate(c *context, w http.ResponseWriter, r *http.Request) {
 		}
 	)
 
-	oldconfig := cluster.OldContainerConfig{
-		ContainerConfig: config,
-		Memory:          0,
-		MemorySwap:      0,
-		CPUShares:       0,
-		CPUSet:          "",
-	}
-
-	if err := json.NewDecoder(r.Body).Decode(&oldconfig); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&config); err != nil {
 		httpError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-
-	// make sure HostConfig fields are consolidated before creating container
-	cluster.ConsolidateResourceFields(&oldconfig)
-	config = oldconfig.ContainerConfig
 
 	// Pass auth information along if present
 	var authConfig *apitypes.AuthConfig

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -21,42 +21,12 @@ type ContainerConfig struct {
 	NetworkingConfig network.NetworkingConfig
 }
 
-// OldContainerConfig contains additional fields for backward compatibility
-// This should be removed after we stop supporting API versions <= 1.8
-// TODO(nishanttotla): Remove this field
-type OldContainerConfig struct {
-	ContainerConfig
-	Memory     int64
-	MemorySwap int64
-	CPUShares  int64  `json:"CpuShares"`
-	CPUSet     string `json:"Cpuset"`
-}
-
 func parseEnv(e string) (bool, string, string) {
 	parts := strings.SplitN(e, ":", 2)
 	if len(parts) == 2 {
 		return true, parts[0], parts[1]
 	}
 	return false, "", ""
-}
-
-// ConsolidateResourceFields is a temporary fix to handle forward/backward compatibility between Docker <1.6 and >=1.7
-func ConsolidateResourceFields(c *OldContainerConfig) {
-	if c.Memory != c.HostConfig.Memory && c.Memory != 0 {
-		c.HostConfig.Memory = c.Memory
-	}
-
-	if c.MemorySwap != c.HostConfig.MemorySwap && c.MemorySwap != 0 {
-		c.HostConfig.MemorySwap = c.MemorySwap
-	}
-
-	if c.CPUShares != c.HostConfig.CPUShares && c.CPUShares != 0 {
-		c.HostConfig.CPUShares = c.CPUShares
-	}
-
-	if c.CPUSet != c.HostConfig.CpusetCpus && c.CPUSet != "" {
-		c.HostConfig.CpusetCpus = c.CPUSet
-	}
 }
 
 // BuildContainerConfig creates a cluster.ContainerConfig from a Config, HostConfig, and NetworkingConfig


### PR DESCRIPTION
This was created to facilitate #1879 but it doesn't make sense to keep around anymore, after Docker versions 1.6/1.7 are long deprecated.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>