### PR TITLE
Adding a SwarmKit based discovery backend

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -24,7 +24,7 @@ var (
 			Flags: []cli.Flag{
 				flStrategy, flFilter,
 				flHosts,
-				flLeaderElection, flLeaderTTL, flManageAdvertise,
+				flLeaderElection, flLeaderTTL, flManageAdvertise, flDiscoveryEnginePort,
 				flTLS, flTLSCaCert, flTLSCert, flTLSKey, flTLSVerify,
 				flRefreshIntervalMin, flRefreshIntervalMax, flFailureRetry, flRefreshRetry,
 				flHeartBeat,

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -86,6 +86,11 @@ var (
 		Value: 3,
 		Usage: "set engine failure retry count",
 	}
+	flDiscoveryEnginePort = cli.IntFlag{
+		Name:  "discovery-engine-port",
+		Value: 2375,
+		Usage: "engine port that exposes the API for swarmkit discovery",
+	}
 	flEnableCors = cli.BoolFlag{
 		Name:  "api-enable-cors, cors",
 		Usage: "enable CORS headers in the remote API",

--- a/discovery/swarmkit/README.md
+++ b/discovery/swarmkit/README.md
@@ -1,0 +1,3 @@
+## SwarmKit Discovery
+
+Docker Swarm comes with a discovery service built based on top of SwarmKit.

--- a/discovery/swarmkit/swarmkit.go
+++ b/discovery/swarmkit/swarmkit.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/discovery"
 	"github.com/docker/swarm/cluster"
@@ -80,11 +79,8 @@ func (s *Discovery) fetch() (discovery.Entries, error) {
 	var addrs []string
 
 	for _, n := range nodeList {
-		// report all nodes that are not in drain mode
-		if n.Spec.Availability != swarm.NodeAvailability("drain") {
-			// Each agent needs to expose the same port
-			addrs = append(addrs, n.Status.Addr+":"+strconv.Itoa(s.agentPort))
-		}
+		// Each agent needs to expose the same port
+		addrs = append(addrs, n.Status.Addr+":"+strconv.Itoa(s.agentPort))
 	}
 
 	return discovery.CreateEntries(addrs)

--- a/discovery/swarmkit/swarmkit.go
+++ b/discovery/swarmkit/swarmkit.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"golang.org/x/net/context"
@@ -25,6 +26,7 @@ type Discovery struct {
 	apiClient  *client.Client
 	uri        string
 	token      string
+	agentPort  int
 }
 
 func init() {
@@ -34,6 +36,10 @@ func init() {
 // Init is exported.
 func Init() {
 	discovery.Register("swarmkit", &Discovery{})
+}
+
+func (s *Discovery) SetAgentPort(discoveryEnginePort int) {
+	s.agentPort = discoveryEnginePort
 }
 
 // Initialize initializes the discovery with the SwarmKit manager's address
@@ -76,7 +82,7 @@ func (s *Discovery) fetch() (discovery.Entries, error) {
 		// report all nodes that are not in drain mode
 		if n.Spec.Availability != swarm.NodeAvailability("drain") {
 			// Each agent needs to expose the same port
-			addrs = append(addrs, n.Status.Addr+":"+defaultAgentPort)
+			addrs = append(addrs, n.Status.Addr+":"+strconv.Itoa(s.agentPort))
 		}
 	}
 

--- a/discovery/swarmkit/swarmkit.go
+++ b/discovery/swarmkit/swarmkit.go
@@ -1,0 +1,132 @@
+package swarmkit
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/discovery"
+	"github.com/docker/swarm/cluster"
+)
+
+const defaultAgentPort = "2375"
+
+// Discovery is exported.
+type Discovery struct {
+	heartbeat  time.Duration
+	ttl        time.Duration
+	httpClient *http.Client
+	apiClient  *client.Client
+	uri        string
+	token      string
+}
+
+func init() {
+	Init()
+}
+
+// Init is exported.
+func Init() {
+	discovery.Register("swarmkit", &Discovery{})
+}
+
+// Initialize initializes the discovery with the SwarmKit manager's address
+func (s *Discovery) Initialize(uri string, heartbeat time.Duration, ttl time.Duration, _ map[string]string) error {
+	// the uri may be a manager address or a docker socket
+	if uri == "" {
+		return errors.New("Swarm Mode manager address not provided")
+	}
+	s.uri = uri
+	s.heartbeat = heartbeat
+	s.ttl = ttl
+
+	// create a client to connect with the Swarm Mode API
+	httpClient, _, err := cluster.NewHTTPClientTimeout("tcp://"+uri, nil, time.Duration(30*time.Second), nil)
+	if err != nil {
+		return err
+	}
+	s.httpClient = httpClient
+
+	apiClient, err := client.NewClient("tcp://"+uri, "", s.httpClient, nil)
+	if err != nil {
+		return err
+	}
+	s.apiClient = apiClient
+
+	return nil
+}
+
+// fetch returns the list of entries for the discovery service at the specified endpoint.
+func (s *Discovery) fetch() (discovery.Entries, error) {
+	ctx := context.Background()
+	nodeList, err := s.apiClient.NodeList(ctx, types.NodeListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch entries, Discovery service returned %s", err.Error())
+	}
+
+	var addrs []string
+
+	for _, n := range nodeList {
+		// report all nodes that are not in drain mode
+		if n.Spec.Availability != swarm.NodeAvailability("drain") {
+			// Each agent needs to expose the same port
+			addrs = append(addrs, n.Status.Addr+":"+defaultAgentPort)
+		}
+	}
+
+	return discovery.CreateEntries(addrs)
+}
+
+// Watch is exported.
+func (s *Discovery) Watch(stopCh <-chan struct{}) (<-chan discovery.Entries, <-chan error) {
+	ch := make(chan discovery.Entries)
+	ticker := time.NewTicker(s.heartbeat)
+	errCh := make(chan error)
+
+	go func() {
+		defer close(ch)
+		defer close(errCh)
+
+		// Send the initial entries if available.
+		currentEntries, err := s.fetch()
+		if err != nil {
+			errCh <- err
+		} else {
+			ch <- currentEntries
+		}
+
+		// Periodically send updates.
+		for {
+			select {
+			case <-ticker.C:
+				newEntries, err := s.fetch()
+				if err != nil {
+					errCh <- err
+					continue
+				}
+
+				// Check if the list of nodes has really changed.
+				if !newEntries.Equals(currentEntries) {
+					ch <- newEntries
+				}
+				currentEntries = newEntries
+			case <-stopCh:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+
+	return ch, errCh
+}
+
+// Register does nothing because Swarm Mode manages the node inventory
+func (s *Discovery) Register(addr string) error {
+	return nil
+}


### PR DESCRIPTION
Addresses https://github.com/docker/swarm/issues/2774

To start a manager with swarmkit discovery
```
swarm manage -H swarm_manager_ip:port --discovery-engine-port 2377 swarmkit://local_engine_ip:port
```

The default value for `discovery-engine-port` is 2375.

TODO
- [x] Provide a discovery option for port in case agents are exposed on a non-default port
- [x] Add support for cluster level events (or the case when the local engine stops being a manager) [follow-up]
- [x] Handle failure or disconnect of Event stream
- [ ] Make sure connection also works with the docker socket [follow-up]

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>