### PR TITLE
Adding "driver" and "dangling" filter options to "docker volume ls"

### DIFF
--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/swarm/cluster"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var engines = []*cluster.Engine{
+	{ID: "59C8F4EC-3A71-44C7-BA50-0496B4D8E548",
+		Name: "swarm-node-0"},
+	{ID: "607B1F15-CECA-41B2-9D26-D2626EB14D8D",
+		Name: "swarm-node-1"},
+}
+
+var mountOne = []types.MountPoint{
+	{Type: "volume",
+		Name:   "localVolumeOne",
+		Driver: "local"},
+	{Type: "bind",
+		Name:   "bindNFS",
+		Driver: ""},
+}
+
+var mountTwo = []types.MountPoint{
+	{Type: "volume",
+		Name:   "sshvolume/withslash",
+		Driver: "vieux/sshfs:latest"},
+}
+
+var containers = cluster.Containers([]*cluster.Container{{
+	Container: types.Container{
+		ID:     "container1-id",
+		Names:  []string{"container1-name1"},
+		Mounts: mountOne,
+	},
+	Engine: engines[0],
+}, {
+	Container: types.Container{
+		ID:     "container2-id",
+		Names:  []string{"container2-name2"},
+		Mounts: mountTwo,
+	},
+	Engine: engines[1],
+}})
+
+var volumes = []*types.Volume{
+	{
+		Name:   "swarm-node-0/localVolumeOne",
+		Driver: "local",
+	},
+	{
+		Name:   "swarm-node-1/sshvolume/withslash",
+		Driver: "vieux/sshfs:latest",
+	},
+	{
+		Name:   "swarm-node-1/sshvolume_unused/withslash",
+		Driver: "vieux/sshfs:latest",
+	},
+	{
+		Name:   "swarm-node-0/localVolume_unused",
+		Driver: "local",
+	},
+	{
+		Name:   "no_slash_unused",
+		Driver: "vieux/sshfs:latest",
+	},
+}
+
+func TestGetUsedVolumes(t *testing.T) {
+	usedVolumes := getUsedVolumes(containers)
+	// Valid checks
+	assert.Contains(t, usedVolumes, "swarm-node-0"+"/"+"localVolumeOne")
+	assert.Contains(t, usedVolumes, "swarm-node-1"+"/"+"sshvolume/withslash")
+	// Invalid checks
+	assert.NotContains(t, usedVolumes, "swarm-node-0"+"/"+"bindNFS")
+}
+
+func TestGetFilteredVolumes(t *testing.T) {
+	//Get dangling volumes
+	danglingVolumes := getFilteredVolumes(containers, volumes, true)
+
+	// Valid checks
+	assert.Contains(t, danglingVolumes, volumes[2])
+	assert.Contains(t, danglingVolumes, volumes[3])
+	assert.Contains(t, danglingVolumes, volumes[4])
+	// Invalid checks
+	assert.NotContains(t, danglingVolumes, volumes[0])
+	assert.NotContains(t, danglingVolumes, volumes[1])
+
+	//Get used volumes
+	usedVolumes := getFilteredVolumes(containers, volumes, false)
+	// Valid checks
+	assert.Contains(t, usedVolumes, volumes[0])
+	assert.Contains(t, usedVolumes, volumes[1])
+	// Invalid checks
+	assert.NotContains(t, usedVolumes, volumes[2])
+	assert.NotContains(t, usedVolumes, volumes[3])
+}


### PR DESCRIPTION
`volume ls` in swarm classic only handles filters with options "node", "name" and "label".
This PR adds support for "driver" and "dangling"

Adding "driver" to the filter option is pretty straightforward.
The "dangling" filter is a bit more involved as the "volume" struct has no "dangling" property.

2 options to support "dangling":
1- add an extra call to the engine to get the dangling volumes
or
2- Iterate through cached "containers" and build a map of volumes that are still referenced by the container, and finally use the delta to delta to determine dangling volumes.

After chatting with @nishanttotla , 1) seems a bit taxing so I decided to go with option 2)
_Note: I am not caching the map for referenced volumes, so we don't have to maintain it, besides, the calls to filter based on "dangling" should be fast and should not be that frequent._ 

**_Repro Steps for `driver`:_**

1- Have at least 2 volumes using 2 separate drivers. 
for ex:
docker volume ls

|DRIVER           |     VOLUME NAME    |
|--------------|---------------------|
|[vieux/sshfs:latest](https://github.com/vieux/docker-volume-sshfs)|sshvolume|
|local                |     testVolume           |

2- Run 
`docker volume ls --filter=driver=local`

3- 
_Expect Results_

|DRIVER           |     VOLUME NAME    |
|--------------|---------------------|
|local                |     testVolume           |

_Actual Results (all volumes returned)_

|DRIVER           |     VOLUME NAME    |
|--------------|---------------------|
|vieux/sshfs:latest|sshvolume|
|local                |     testVolume           |

_**Repro Steps for `dangling`:**_

1- Have at least 2 volumes with one volume that is dangling (not used).
(sshvolume in this example is dangling)
docker volume ls

|DRIVER           |     VOLUME NAME    |
|--------------|---------------------|
|vieux/sshfs:latest|sshvolume|
|local                |     testVolume           |

2- Run
`docker volume ls --filter=dangling=true`

3- 
_Expect Results_

|DRIVER           |     VOLUME NAME    |
|--------------|---------------------|
|vieux/sshfs:latest|sshvolume|

_Actual Results (all volumes returned)_

|DRIVER           |     VOLUME NAME    |
|--------------|---------------------|
|vieux/sshfs:latest|sshvolume|
|local                |     testVolume           |




Signed-off-by: Dani Louca <dani.louca@docker.com>