### PR TITLE
Collect events continuously from an engine

### DIFF
--- a/cluster/event_monitor.go
+++ b/cluster/event_monitor.go
@@ -1,6 +1,8 @@
 package cluster
 
 import (
+	"time"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/swarm/swarmclient"
@@ -9,24 +11,29 @@ import (
 
 //EventsMonitor monitors events
 type EventsMonitor struct {
-	stopChan chan struct{}
-	cli      swarmclient.SwarmAPIClient
-	handler  func(msg events.Message) error
+	stopChan    chan struct{}
+	cli         swarmclient.SwarmAPIClient
+	handler     func(msg events.Message) error
+	lastEventAt time.Time
 }
 
 // NewEventsMonitor returns an EventsMonitor
 func NewEventsMonitor(cli swarmclient.SwarmAPIClient, handler func(msg events.Message) error) *EventsMonitor {
 	return &EventsMonitor{
-		cli:      cli,
-		handler:  handler,
-		stopChan: make(chan struct{}),
+		cli:         cli,
+		handler:     handler,
+		stopChan:    make(chan struct{}),
+		lastEventAt: time.Now().UTC(),
 	}
 }
 
 // Start starts the EventsMonitor
 func (em *EventsMonitor) Start(ec chan error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	responseStream, errStream := em.cli.Events(ctx, types.EventsOptions{})
+	options := types.EventsOptions{
+		Since: em.lastEventAt.Format(time.RFC3339),
+	}
+	responseStream, errStream := em.cli.Events(ctx, options)
 
 	go func() {
 		defer cancel()
@@ -37,6 +44,8 @@ func (em *EventsMonitor) Start(ec chan error) {
 					ec <- err
 					return
 				}
+				// if event stream is broken, it should use `--since` in restart to pick up from the last event
+				em.lastEventAt = time.Unix(0, event.TimeNano+1).UTC()
 			case err := <-errStream:
 				ec <- err
 				return

--- a/test/integration/api/events.bats
+++ b/test/integration/api/events.bats
@@ -35,7 +35,7 @@ function teardown() {
 	[[ "${output}" == *"create"* ]]
 	[[ "${output}" == *"start"* ]]
 	[[ "${output}" == *"die"* ]]
-	
+
 	# after ok, remove the log file
 	rm -f "$log_file"
 }
@@ -62,4 +62,50 @@ function teardown() {
 
 	# after ok, remove the log file
 	rm -f "$log_file"
+}
+
+@test "docker events pick up events at reconnect" {
+	start_docker_with_busybox 1
+
+	# create a blank temp file for discovery
+	DISCOVERY_FILE=$(mktemp)
+	DISCOVERY="file://$DISCOVERY_FILE"
+	for host in ${HOSTS[@]}; do
+		echo "$host" >> $DISCOVERY_FILE
+	done
+
+	swarm_manage --engine-refresh-min-interval "1s" --engine-refresh-max-interval "1s" --engine-failure-retry 2 "$DISCOVERY"
+
+	eval "docker_swarm info | grep -q -i 'Status: Healthy'"
+
+	# start events, report real time events to $log_file
+	local log_file=$(mktemp)
+	docker_swarm events > "$log_file" &
+	local events_pid="$!"
+
+	# This should emit 3 events: create, start, die.
+	docker_swarm run -d --name test_container --restart always busybox sleep 100
+
+	# events might take a little bit to show up, wait until we get the last one.
+	retry 5 0.5 grep -q "start" "$log_file"
+
+	# Restart the node
+	docker_host stop ${DOCKER_CONTAINERS[0]}
+	# Wait for swarm to detect node failure
+	retry 5 1 eval "docker_swarm info | grep -q -i 'Status: Unhealthy'"
+
+	# Restart node
+	docker_host start ${DOCKER_CONTAINERS[0]}
+	# Wait for swarm to detect node recovery
+	retry 15 1 eval "docker_swarm info | grep -q -i 'Status: Healthy'"
+
+	# the container should be restarted and docker events should capture it
+	retry 5 0.5 eval "[ $(grep -c 'container start' ${log_file}) -ge 2 ]"
+
+	# clean up `docker events`
+	kill "$events_pid"
+
+	# after ok, remove the log file
+	rm -f "$log_file"
+	rm -f "$DISCOVERY_FILE"
 }


### PR DESCRIPTION
Swarm manager collects events from each engine thru `events` API. Event stream from an engine may be broken for various reasons. While manager reconnects to collect events, events from that engine between reconnects are lost. This PR remembers the timestamp of last event from an engine, and uses it with `--since` to get the missing events. 

This PR replaces #2717 after the events code was reorganized. Like that PR points out, this change would make an API change incompatible with Docker 1.9, which by now we should be ready to drop support for.

This change would also finally close #2749.

cc @wsong @allencloud @vieux 

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>