### PR TITLE
Log engine refresh errors at error log level

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -960,7 +960,7 @@ func (e *Engine) refreshLoop() {
 				log.WithFields(log.Fields{"id": e.ID, "name": e.Name}).Debugf("Engine update succeeded")
 			}
 		} else {
-			log.WithFields(log.Fields{"id": e.ID, "name": e.Name}).Debugf("Engine refresh failed")
+			log.WithFields(log.Fields{"id": e.ID, "name": e.Name}).Errorf("Engine refresh failed: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
This improves logging when engine refreshes fail, including logging at the error log level instead of the debug log level.