### PR TITLE
Setting the http status code based on known error messages

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -690,6 +690,8 @@ func postContainersCreate(c *context, w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "Conflict") {
 			httpError(w, err.Error(), http.StatusConflict)
+		} else if strings.Contains(err.Error(), "does not exist") {
+			httpError(w, err.Error(), http.StatusNotFound)
 		} else {
 			httpError(w, err.Error(), http.StatusInternalServerError)
 		}


### PR DESCRIPTION
Signed-off-by: Dani Louca <dani.louca@docker.com>

Swarm uses the docker client API to communicate with the engine.
As you can see [here](https://github.com/moby/moby/blob/master/client/container_create.go#L45-L51 ) and in case of an error, the `serverResp.statusCode` is not returned.
Currently swarm guesses the return code which makes it inconsistent with the status code documented [here](https://docs.docker.com/engine/api/v1.30/#operation/ContainerCreate) 

This is not limited to `ContainerCreate` but because of the scope of the issue, the fix in this PR only addresses the container create api call only.

The error messages used in the helper function `GetHTTPErrorStatusCode` are from this engine method https://github.com/moby/moby/blob/17.05.x/api/server/httputils/errors.go#L56-L68





