### PR TITLE
fix "docker ps" shows stale container status

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -580,9 +580,6 @@ func getContainersJSON(c *context, w http.ResponseWriter, r *http.Request) {
 		// make changes without messing with cluster.Container.
 		tmp := (*container).Container
 
-		// Update the Status. The one we have is stale from the last `docker ps` the engine sent.
-		// `Status()` will generate a new one
-		tmp.Status = cluster.FullStateString(container.Info.State)
 		if !container.Engine.IsHealthy() {
 			tmp.Status = "Host Down"
 		}

--- a/cluster/container.go
+++ b/cluster/container.go
@@ -1,13 +1,11 @@
 package cluster
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stringid"
-	units "github.com/docker/go-units"
 )
 
 // Container is exported
@@ -49,48 +47,6 @@ func HealthString(state *types.ContainerState) string {
 		return types.NoHealthcheck
 	}
 	return state.Health.Status
-}
-
-// FullStateString returns human-readable description of the state
-func FullStateString(state *types.ContainerState) string {
-	startedAt, _ := time.Parse(time.RFC3339Nano, state.StartedAt)
-	finishedAt, _ := time.Parse(time.RFC3339Nano, state.FinishedAt)
-	if state.Running {
-		if state.Paused {
-			return fmt.Sprintf("Up %s (Paused)", units.HumanDuration(time.Now().UTC().Sub(startedAt)))
-		}
-		if state.Restarting {
-			return fmt.Sprintf("Restarting (%d) %s ago", state.ExitCode, units.HumanDuration(time.Now().UTC().Sub(finishedAt)))
-		}
-		// Container is Up. Add Health check info when healthcheck is defined.
-		healthText := ""
-		if h := state.Health; h != nil {
-			switch h.Status {
-			case types.Starting:
-				healthText = "health: starting"
-			default: // Healthy and Unhealthy are clear on their own
-				healthText = h.Status
-			}
-		}
-		if len(healthText) > 0 {
-			return fmt.Sprintf("Up %s (%s)", units.HumanDuration(time.Now().UTC().Sub(startedAt)), healthText)
-		}
-		return fmt.Sprintf("Up %s", units.HumanDuration(time.Now().UTC().Sub(startedAt)))
-	}
-
-	if state.Dead {
-		return "Dead"
-	}
-
-	if startedAt.IsZero() {
-		return "Created"
-	}
-
-	if finishedAt.IsZero() {
-		return ""
-	}
-
-	return fmt.Sprintf("Exited (%d) %s ago", state.ExitCode, units.HumanDuration(time.Now().UTC().Sub(finishedAt)))
 }
 
 // Refresh container


### PR DESCRIPTION

If the container status-change event is not delivered to swarm manager or not handled successfully by swarm manager due to some reasons (e.g. transient network issue or node issue), the stale status info from `docker ps` will be there for long time.

The reason is because:
https://github.com/docker/swarm/blob/master/api/handlers.go#L580
```
		tmp.Status = cluster.FullStateString(container.Info.State)
```
`refreshLoop()` calls `RefreshContainers(false)`, the param `false` means `container.Info` does NOT get updated in `ucp-swarm-manager`'s cache. 

On the other hand, `refreshLoop()` makes `container.Container` get the latest info from docker engine, so `tmp` can directly use the `Status` field of `container.Container`.

In addition, for container events handling, it will call `e.refreshContainer(msg.ID, true)` which will update both `container.Container` and `container.Info` using the latest info from docker engine. So using the `Status` from `container.Container` is always right.
