### PR TITLE
api: add undocumented /grpc endpoint available since API 1.40

### DIFF
--- a/api/primary.go
+++ b/api/primary.go
@@ -84,6 +84,7 @@ var routes = map[string]map[string]handler{
 		"/networks/{networkid:.*}/connect":    proxyNetworkConnect,
 		"/networks/{networkid:.*}/disconnect": networkDisconnect,
 		"/volumes/create":                     postVolumesCreate,
+		"/grpc":                               postGRPC,
 
 		// TODO(dperny): this route is WIP, remove this comment
 		"/session": postSession,


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>

This allows to use buildx with docker driver on swarm.