### PR TITLE
Fixing CI/Test 

### DIFF
--- a/dind/Dockerfile
+++ b/dind/Dockerfile
@@ -1,0 +1,34 @@
+# Dockerfile for building Docker
+FROM debian:jessie
+
+# compile and runtime deps
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        iptables \
+        procps \
+        e2fsprogs \
+        xz-utils \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV VERSION dev
+RUN curl -L -o /usr/local/bin/docker https://master.dockerproject.org/linux/x86_64/docker \
+    && chmod +x /usr/local/bin/docker
+RUN curl -L -o /usr/local/bin/dockerd https://master.dockerproject.org/linux/x86_64/dockerd \
+    && chmod +x /usr/local/bin/dockerd
+RUN curl -L -o /usr/local/bin/runc https://master.dockerproject.org/linux/x86_64/docker-runc \
+    && chmod +x /usr/local/bin/runc
+RUN curl -L -o /usr/local/bin/containerd https://master.dockerproject.org/linux/x86_64/docker-containerd \
+    && chmod +x /usr/local/bin/containerd
+RUN curl -L -o /usr/local/bin/containerd-shim https://master.dockerproject.org/linux/x86_64/docker-containerd-shim \
+    && chmod +x /usr/local/bin/containerd-shim
+RUN curl -L -o /usr/local/bin/docker-proxy https://master.dockerproject.org/linux/x86_64/docker-proxy \
+    && chmod +x /usr/local/bin/docker-proxy
+
+RUN curl -L -o /dind https://raw.githubusercontent.com/docker/docker/master/hack/dind \
+    && chmod +x /dind
+
+VOLUME /var/lib/docker
+
+ENTRYPOINT ["/dind"]

--- a/dind/README.md
+++ b/dind/README.md
@@ -1,0 +1,3 @@
+# Docker in Docker
+
+used by the CI to run the integration tests

--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -230,8 +230,8 @@ function start_docker() {
 			${DOCKER_IMAGE}:${DOCKER_VERSION} \
 			sh -c "\
 				rm /var/run/docker.pid ; \
-				rm /var/run/docker/libcontainerd/docker-containerd.pid ; \
-				rm /var/run/docker/libcontainerd/docker-containerd.sock ; \
+				rm /var/run/docker/libcontainerd/containerd.pid ; \
+				rm /var/run/docker/libcontainerd/containerd.sock ; \
 				hostname node-$i && \
 				$DOCKER_START_COMMAND -H 127.0.0.1:$port \
 					-H=unix:///var/run/docker.sock \


### PR DESCRIPTION
Currently swarm build uses a swarm image that from this repo/branch https://github.com/aluzzardi/dind/tree/dev 
However we no longer use the `docker-` prefix for `runc` and `containerd` and that is currently causing the dind image to fail to start the daemon.

In this PR, I moved the Dockerfile to swarm repo and fixed the file names.
In addition, test helper function.

cc: @thaJeztah @dperny 
@thaJeztah : Can you help setting the auto build, once we have an image on hub, I will update jenkins.
 

Signed-off-by: Dani Louca <dani.louca@docker.com>