### PR TITLE
Fix docs license ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ reconciliation, load balancing, service discovery, built-in certificate rotation
 
 Copyright © 2014-2018 Docker, Inc. All rights reserved, except as follows. Code
 is released under the Apache 2.0 license. The README.md file, and files in the
-"docs" folder are licensed under the Creative Commons Attribution 4.0
+"docs" folder are licensed under the Creative Commons Attribution-ShareAlike 4.0
 International License under the terms and conditions set forth in the file
 "LICENSE.docs". You may obtain a duplicate copy of the same license, titled
-CC-BY-SA-4.0, at http://creativecommons.org/licenses/by/4.0/.
+CC-BY-SA-4.0, at https://creativecommons.org/licenses/by-sa/4.0/.


### PR DESCRIPTION
fix #2833

Appears to have always been CC-BY-SA not CC-BY.

Signed-off-by: Justin Cormack <justin@specialbusservice.com>